### PR TITLE
feat(release): notarize macOS builds via Apple ID; guard tag pushes against missing signing secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
 
       - name: Configure & Build
         run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$QT_ROOT_DIR
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$QT_ROOT_DIR \
+            -DANOA_VERSION_OVERRIDE="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}"
           cmake --build build --parallel
 
       - name: Package portable bundle
@@ -203,7 +204,8 @@ jobs:
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH=$QT_ROOT_DIR \
-            -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+            -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+            -DANOA_VERSION_OVERRIDE="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}"
           cmake --build build --parallel
 
       - name: Verify universal binaries
@@ -351,7 +353,7 @@ jobs:
 
       - name: Configure & Build
         run: |
-          cmake -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$env:QT_ROOT_DIR"
+          cmake -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="$env:QT_ROOT_DIR" -DANOA_VERSION_OVERRIDE="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}"
           cmake --build build --config Release
 
       - name: Deploy Qt DLLs & WebEngine resources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
     tags:
       - 'v*.*.*'
   # Manual runs build and smoke-test all packages without publishing —
-  # the release/tap steps only run for tag pushes.
+  # the release/tap steps only run for tag pushes. Tag pushes REQUIRE the
+  # macOS signing secrets (guarded below): an unsigned release must never
+  # reach GitHub Releases / the Homebrew tap.
   workflow_dispatch:
 
 env:
@@ -162,6 +164,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Fail fast on tag pushes when signing secrets are missing — otherwise
+      # the release job would publish an ad-hoc (Gatekeeper-blocked) build to
+      # GitHub Releases and the Homebrew tap. Manual dispatch runs are exempt:
+      # they only produce throwaway artifacts.
+      - name: Require signing secrets on tag pushes
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          missing=""
+          for var in MACOS_CERT_P12_BASE64 APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            [ -z "${!var:-}" ] && missing="$missing $var"
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Tag push requires macOS signing secrets, missing:$missing"
+            echo "Refusing to publish an unsigned macOS release. Set the secrets or delete the tag."
+            exit 1
+          fi
+
       # aqt's mac desktop Qt is a universal (x86_64 + arm64) build, so a single
       # job produces one binary that runs natively on Intel and Apple Silicon.
       - uses: jurplel/install-qt-action@v4
@@ -255,9 +279,9 @@ jobs:
       - name: Apply entitlements & notarize
         if: ${{ steps.cert.outputs.identity != '' }}
         env:
-          MACOS_NOTARY_KEY_P8_BASE64: ${{ secrets.MACOS_NOTARY_KEY_P8_BASE64 }}
-          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
-          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
           APP=build/anoa-browser.app
@@ -273,12 +297,11 @@ jobs:
           sign --entitlements "$ENT" "$APP"
           codesign --verify --deep --strict --verbose=2 "$APP"
 
-          echo "$MACOS_NOTARY_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/notary.p8"
           ditto -c -k --keepParent "$APP" "$RUNNER_TEMP/notarize.zip"
           xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
-            --key "$RUNNER_TEMP/notary.p8" \
-            --key-id "$MACOS_NOTARY_KEY_ID" \
-            --issuer "$MACOS_NOTARY_ISSUER_ID" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
             --wait
           xcrun stapler staple "$APP"
           xcrun stapler validate "$APP"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,14 @@
 cmake_minimum_required(VERSION 3.16)
 project(anoa-browser VERSION 0.3.1 LANGUAGES CXX)
 
+# CI injects the git tag here so the tag is the single source of truth for the
+# version — CMakeLists.txt never needs a manual bump for releases. The value
+# above is just the default for local builds.
+set(ANOA_VERSION_OVERRIDE "" CACHE STRING "Version override (CI passes the git tag)")
+if(ANOA_VERSION_OVERRIDE)
+    string(REGEX REPLACE "^v" "" PROJECT_VERSION "${ANOA_VERSION_OVERRIDE}")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/README.md
+++ b/README.md
@@ -346,9 +346,8 @@ On macOS, `DISPLAY` is not required. On Linux without a display server, `QPA_PLA
 
 ## Releasing (maintainers)
 
-1. Bump `project(... VERSION ...)` in `CMakeLists.txt` and commit.
-2. `git tag vX.Y.Z && git push origin vX.Y.Z`
-3. CI builds Linux / macOS / Windows, signs + notarizes the macOS app, publishes the GitHub Release, and updates the Homebrew tap automatically.
+1. Create a tag `vX.Y.Z` — via GitHub (**Releases → Draft a new release → Choose a tag → Create new tag**) or CLI (`git tag vX.Y.Z && git push origin vX.Y.Z`). The tag name is the version: CI injects it into the build (`ANOA_VERSION_OVERRIDE`), so `CMakeLists.txt` never needs a manual bump.
+2. CI builds Linux / macOS / Windows, signs + notarizes the macOS app, publishes the GitHub Release, and updates the Homebrew tap automatically.
 
 Tag pushes require the macOS signing secrets (`MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`) — CI fails fast if any are missing, so an unsigned build can never be released. Without `HOMEBREW_TAP_TOKEN` the tap update is skipped (warning only). To smoke-test the pipeline without publishing, run the Release workflow manually (`workflow_dispatch`) — artifacts only, no release, no tap update.
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,16 @@ On macOS, `DISPLAY` is not required. On Linux without a display server, `QPA_PLA
 
 ---
 
+## Releasing (maintainers)
+
+1. Bump `project(... VERSION ...)` in `CMakeLists.txt` and commit.
+2. `git tag vX.Y.Z && git push origin vX.Y.Z`
+3. CI builds Linux / macOS / Windows, signs + notarizes the macOS app, publishes the GitHub Release, and updates the Homebrew tap automatically.
+
+Tag pushes require the macOS signing secrets (`MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`) — CI fails fast if any are missing, so an unsigned build can never be released. Without `HOMEBREW_TAP_TOKEN` the tap update is skipped (warning only). To smoke-test the pipeline without publishing, run the Release workflow manually (`workflow_dispatch`) — artifacts only, no release, no tap update.
+
+---
+
 ## Architecture
 
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ brew trust porcupine-md/tap        # tap ships a cask + formula
 brew install --cask anoa-browser
 ```
 
-Installs `anoa-browser` and `anoa-term` into your `PATH`. The app is ad-hoc signed (not notarized); the cask clears the quarantine flag on install so it launches normally with no extra steps.
+Installs `anoa-browser` and `anoa-term` into your `PATH`. The app is Developer ID signed and notarized by Apple, so it opens with no Gatekeeper warnings. (The cask still clears the quarantine flag on install — a harmless no-op safety net.)
 
 ### Linux (Homebrew)
 


### PR DESCRIPTION
## What

- Switch macOS notarization from App Store Connect API key (`.p8`) to the Apple ID route (`--apple-id --password --team-id`) — same credential set as jonggrang-desktop, one less secret family to maintain
- Add a fail-fast guard on tag pushes: if any signing secret is missing the macOS job aborts before building, so an unsigned (Gatekeeper-blocked) build can never reach GitHub Releases / the Homebrew tap. Manual `workflow_dispatch` runs are exempt (artifacts only)
- Header comment documents the requirement

## Secrets (already configured on the repo)

`MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`, `HOMEBREW_TAP_TOKEN`

## How to verify

1. Actions → Release → Run workflow on this branch — all jobs green, macOS leg signs + notarizes + staples (does not publish; tap untouched)
2. After merge: push a tag `v*.*.*` → release + Homebrew tap update run automatically