### PR TITLE
fix(release): install qtserialport on macOS — macdeployqt aborts on QtSerialPort rpath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,16 +189,20 @@ jobs:
 
       # aqt's mac desktop Qt is a universal (x86_64 + arm64) build, so a single
       # job produces one binary that runs natively on Intel and Apple Silicon.
+      # qtserialport: QtWebEngineCore references QtSerialPort (Web Serial API);
+      # without the module present macdeployqt aborts with "Cannot resolve
+      # rpath @rpath/QtSerialPort.framework". The -v2 cache key forces a fresh
+      # Qt install including the new module instead of restoring the old cache.
       - uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
           host: mac
           target: desktop
           arch: clang_64
-          modules: qtwebchannel qtwebsockets qtpositioning qtwebengine
+          modules: qtwebchannel qtwebsockets qtpositioning qtwebengine qtserialport
           install-deps: true
           cache: true
-          cache-key-prefix: qt-${{ env.QT_VERSION }}-macos-clang64
+          cache-key-prefix: qt-${{ env.QT_VERSION }}-macos-clang64-v2
 
       - name: Configure & Build (universal)
         run: |


### PR DESCRIPTION
## Problem

macOS leg of the v0.3.1 tag run failed in `macdeployqt`:

```
ERROR: Cannot resolve rpath "@rpath/QtSerialPort.framework/Versions/A/QtSerialPort"
```

`QtWebEngineCore` references `QtSerialPort` (Web Serial API). The aqt module list did not include `qtserialport`, so the framework is absent from the Qt installation and macdeployqt aborts instead of deploying it. Linux/Windows passed — their packagers are not as strict. [Failed run](https://github.com/porcupine-md/anoa-browser/actions/runs/30560644174).

## Fix

- Add `qtserialport` to the macOS job's `modules:`
- Bump `cache-key-prefix` to `-v2` — required, otherwise the old cached Qt (without qtserialport) is restored and the error repeats

## After merge

Re-tag `v0.3.1` on the new master (delete + recreate the tag) so the release runs with this fix; the existing v0.3.1 GitHub Release gets the assets attached and the Homebrew tap updates automatically.