### PR TITLE
feat(packaging): an AppImage for Linux, and the NSS shadowing it exposed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,10 +240,51 @@ jobs:
           grep -q -- '--gfx' /tmp/term-help.txt
           kill $BROWSER_PID
 
+      # The AppImage is the same bundle in a self-mounting file: one download,
+      # chmod +x, run. It is built from dist/anoa rather than from a fresh
+      # deploy so it inherits every decision above, including which libraries
+      # come from the host.
+      - name: Build the AppImage
+        run: |
+          scripts/build-appimage.sh dist/anoa anoa-x86_64.AppImage
+
+      - name: Smoke test the AppImage
+        run: |
+          # Runs the real file, not an extracted copy: a GitHub runner has no
+          # FUSE, so this also proves the embedded runtime falls back cleanly
+          # rather than only proving the payload is intact.
+          chmod +x anoa-x86_64.AppImage
+          version="$(APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-x86_64.AppImage --version)"
+          echo "AppImage reports: $version"
+          case "$version" in
+            "anoa "*) ;;
+            *) echo "::error::AppImage did not report a version"; exit 1 ;;
+          esac
+
+          # The one thing a packaging mistake breaks first, and the reason the
+          # tarball smoke test exists in the same shape above.
+          APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-x86_64.AppImage \
+            --headless --no-sandbox --port 9444 &
+          for i in $(seq 1 45); do
+            (echo > /dev/tcp/127.0.0.1/9444) 2>/dev/null && break
+            sleep 1
+          done
+          (echo > /dev/tcp/127.0.0.1/9444) 2>/dev/null \
+            || { echo "::error::AppImage browser never came up"; exit 1; }
+          title="$(APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-x86_64.AppImage \
+                     open example.com --port 9444 | head -1)"
+          echo "AppImage opened: $title"
+          pkill -x anoa || true
+
       - uses: actions/upload-artifact@v4
         with:
           name: anoa-linux-x86_64
           path: anoa-linux-x86_64.tar.gz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: anoa-x86_64-appimage
+          path: anoa-x86_64.AppImage
 
   build-macos:
     name: macOS universal (x86_64 + arm64)
@@ -583,6 +624,7 @@ jobs:
           files: |
             *.tar.gz
             *.zip
+            *.AppImage
           generate_release_notes: true
 
       # Skips (does not fail the release) when HOMEBREW_TAP_TOKEN is not set —

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,9 +167,29 @@ jobs:
           # and libEGL.so.1 directly, and a bare container has no GL packages at
           # all, so excluding them outright broke --headless, which needs no GL
           # whatsoever.
+          #
+          # NSS joins them for a third reason, found by an AppImage smoke test
+          # on a GitHub runner:
+          #
+          #   nss_util.cc(239) Error initializing NSS with a persistent database
+          #     libsoftokn3.so: cannot open shared object file
+          #
+          # libnss3.so is a link-time dependency, so the walk above bundles it —
+          # but NSS loads libsoftokn3, libfreebl3 and libnssckbi at RUNTIME, so
+          # ldd never names them and no dependency walk can find them. The
+          # bundled libnss3 then shadows the host's complete, coherent set and
+          # goes looking for modules that were never packaged. Chromium reads
+          # certificates through NSS, so the symptom is that every HTTPS page
+          # fails while everything local still works.
+          #
+          # Host-first fixes it wherever NSS is installed, which is every
+          # ordinary distro. A host with no NSS at all still needs libnss3 —
+          # the Dockerfile has always installed it for exactly this reason.
           mkdir -p "$bundle/lib/hostfirst"
           for hf in libGL.so libGLX.so libGLdispatch.so libEGL.so libOpenGL.so libglapi.so \
-                    libX11.so libstdc++.so; do
+                    libX11.so libstdc++.so \
+                    libnss3.so libnssutil3.so libsmime3.so libnspr4.so \
+                    libplc4.so libplds4.so; do
             for f in "$bundle"/lib/${hf}*; do
               [ -e "$f" ] && mv "$f" "$bundle/lib/hostfirst/" 2>/dev/null || true
             done
@@ -273,8 +293,18 @@ jobs:
             || { echo "::error::AppImage browser never came up"; exit 1; }
           title="$(APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-x86_64.AppImage \
                      open example.com --port 9444 | head -1)"
-          echo "AppImage opened: $title"
+          echo "AppImage opened: [$title]"
           pkill -x anoa || true
+
+          # Asserted, not just printed. The first version of this step only
+          # checked --version and reported success while `open` returned
+          # nothing at all — the bundle was shadowing the host's NSS and every
+          # HTTPS load was failing. A smoke test that cannot see that is not
+          # worth running.
+          if [ -z "$title" ]; then
+            echo "::error::AppImage started but could not load a page"
+            exit 1
+          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -128,16 +128,22 @@ That unpacks the whole payload on every invocation: about 6 seconds per command
 against 1 for the tarball. Fine for a one-off, wrong for an agent loop — use the
 tarball or the container image there instead.
 
-**HTTPS needs two packages from the host**, on a truly bare system:
+**HTTPS needs NSS from the host** on a system that has none — a stripped
+container, not a distro:
 
 ```bash
-sudo apt install ca-certificates libnss3   # Debian/Ubuntu
+sudo apt install libnss3 ca-certificates   # Debian/Ubuntu
 ```
 
-Chromium reads certificates through NSS, and NSS loads its modules at runtime
-rather than linking them, so no bundle ever names them. Any ordinary desktop
-already has both. Without them a page load fails with
-`nss_util.cc ... Error initializing NSS`.
+Chromium reads certificates through NSS, and `libnss3` loads `libsoftokn3`,
+`libfreebl3` and `libnssckbi` at runtime instead of linking them — so `ldd`
+never names them and no bundle can package them by walking dependencies.
+Without them the browser still starts and local commands still work; only page
+loads fail, with `nss_util.cc ... Error initializing NSS`.
+
+Every ordinary distro already has NSS. Measured on a bare `debian:12-slim` with
+nothing installed: `--version`, the browser and `eval` all work; `open` does
+not until `libnss3` is there.
 
 ### Linux (portable tarball)
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,45 @@ install-linux.sh --prefix /opt/anoa   # somewhere other than ~/.local
 install-linux.sh --uninstall          # remove it again
 ```
 
+### Linux (AppImage)
+
+One file. Download, make it executable, run it — no unpacking, no install, no
+root:
+
+```bash
+chmod +x anoa-x86_64.AppImage
+./anoa-x86_64.AppImage --headless --port 9222
+./anoa-x86_64.AppImage open example.com
+```
+
+Verified on a stock Ubuntu 24.04: headless, a real window with GLX, the terminal
+viewer, and the agent commands.
+
+It carries its own FUSE, so it does **not** need the `libfuse2` package that
+Ubuntu dropped in 22.04 — the runtime AppImage's own tooling embeds by default
+fails there with `dlopen(): error loading libfuse.so.2` before anything runs.
+
+**On a host with no FUSE at all** — most containers — run it without mounting:
+
+```bash
+APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-x86_64.AppImage --version
+```
+
+That unpacks the whole payload on every invocation: about 6 seconds per command
+against 1 for the tarball. Fine for a one-off, wrong for an agent loop — use the
+tarball or the container image there instead.
+
+**HTTPS needs two packages from the host**, on a truly bare system:
+
+```bash
+sudo apt install ca-certificates libnss3   # Debian/Ubuntu
+```
+
+Chromium reads certificates through NSS, and NSS loads its modules at runtime
+rather than linking them, so no bundle ever names them. Any ordinary desktop
+already has both. Without them a page load fails with
+`nss_util.cc ... Error initializing NSS`.
+
 ### Linux (portable tarball)
 
 The release tarball is self-contained: one executable, every shared library it needs under `lib/`, its resources and translations, plus a launcher script that wires them together. Terminal mode is a subcommand of that executable, so the tarball contains no second binary.

--- a/resources/anoa.sh
+++ b/resources/anoa.sh
@@ -29,12 +29,22 @@ export LD_LIBRARY_PATH="${DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 # Some libraries have to come from the host whenever the host has them.
 #
 # lib/hostfirst holds our copies of the GLVND dispatch libraries — libGL,
-# libGLX, libGLdispatch, libEGL, libOpenGL — together with libX11 and
-# libstdc++. The dispatch layers exist to find the graphics driver installed on
+# libGLX, libGLdispatch, libEGL, libOpenGL — together with libX11, libstdc++
+# and NSS. The dispatch layers exist to find the graphics driver installed on
 # the machine they run on, so shipping them in front of the system's makes them
 # hunt for the build box's driver instead. libX11 and libstdc++ are there
 # because the host's Mesa gets dlopen()ed into this process and is built
 # against the host's copies of both.
+#
+# NSS is there because Chromium reads certificates through it, and libnss3
+# loads libsoftokn3, libfreebl3 and libnssckbi at RUNTIME — so ldd never names
+# them, no dependency walk packages them, and a bundled libnss3 that shadows
+# the host's then hunts for modules that are not there:
+#
+#   nss_util.cc(239) Error initializing NSS ...
+#     libsoftokn3.so: cannot open shared object file
+#
+# which shows up as every HTTPS page failing while everything local works.
 #
 # Either way the symptom is the same, and it is what a desktop user sees:
 #
@@ -60,7 +70,12 @@ if [ -d "${DIR}/lib/hostfirst" ]; then
   ldc="$(command -v ldconfig || echo /sbin/ldconfig)"
   cache="$("$ldc" -p 2>/dev/null || true)"
   missing=""
-  for so in "${DIR}"/lib/hostfirst/*.so.*; do
+  # Both spellings. The GL libraries carry a version suffix (libGL.so.1) but
+  # the NSS ones do not (libnss3.so, libsmime3.so), and a glob of *.so.* alone
+  # skipped every one of them: they sat in lib/hostfirst, never reached the
+  # shim, and the binary died with "libsmime3.so: cannot open shared object
+  # file" on any host without NSS.
+  for so in "${DIR}"/lib/hostfirst/*.so "${DIR}"/lib/hostfirst/*.so.*; do
     [ -e "$so" ] || continue
     base="${so##*/}"
     case "$cache" in
@@ -72,7 +87,8 @@ if [ -d "${DIR}/lib/hostfirst" ]; then
     # Only the gaps go on the path, through a directory of symlinks rebuilt
     # every launch so it cannot go stale when GL packages are installed later.
     shim="${XDG_CACHE_HOME:-${HOME:-/tmp}/.cache}/anoa/hostfirst"
-    if mkdir -p "$shim" 2>/dev/null && rm -f "$shim"/*.so.* 2>/dev/null; then
+    if mkdir -p "$shim" 2>/dev/null \
+       && rm -f "$shim"/*.so "$shim"/*.so.* 2>/dev/null; then
       for base in $missing; do
         ln -sf "${DIR}/lib/hostfirst/${base}" "${shim}/${base}" 2>/dev/null || true
       done

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Build anoa-x86_64.AppImage from the portable Linux bundle.
+#
+# The bundle is already the hard part: one binary, its libraries, the Qt
+# plugins, QtWebEngineProcess, the resource paks, and a launcher that decides
+# which libraries come from the host. An AppImage is that directory plus three
+# things — an AppRun, a .desktop file and an icon — squashed into a
+# self-mounting archive.
+#
+# So this deliberately does NOT use linuxdeploy or its Qt plugin. Those exist to
+# work out what to bundle, which release.yml has already done with more care
+# than a generic tool can: it knows that libGL, libX11 and libstdc++ must come
+# from the host, and a tool that helpfully bundles them would put back the
+# "Could not initialize GLX" this project spent a release fixing.
+#
+# Usage:
+#   scripts/build-appimage.sh <bundle-dir> [output.AppImage]
+#
+# where <bundle-dir> is the `anoa` directory from anoa-linux-x86_64.tar.gz, or
+# any directory with the same shape.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUNDLE="${1:?usage: build-appimage.sh <bundle-dir> [output.AppImage]}"
+OUTPUT="${2:-anoa-x86_64.AppImage}"
+
+if [ ! -x "$BUNDLE/anoa" ] || [ ! -f "$BUNDLE/anoa.sh" ]; then
+    echo "not an anoa bundle: $BUNDLE" >&2
+    echo "expected anoa and anoa.sh inside it" >&2
+    exit 2
+fi
+
+VERSION="$(sed -n 's/.*project(anoa VERSION \([0-9.]*\).*/\1/p' "$ROOT/CMakeLists.txt")"
+VERSION="${VERSION:-0.0.0}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+APPDIR="$WORK/AppDir"
+
+echo "==> assembling AppDir (anoa $VERSION)"
+mkdir -p "$APPDIR"
+cp -a "$BUNDLE"/. "$APPDIR"/
+
+# AppRun is the entry point. It is a wrapper rather than a symlink to anoa.sh
+# because the AppImage runtime invokes it with the user's arguments and nothing
+# else: $APPDIR is the only reliable way to find the payload, and anoa.sh's own
+# BASH_SOURCE resolution would otherwise be resolving a path inside a mount that
+# moves on every run.
+cat > "$APPDIR/AppRun" <<'APPRUN'
+#!/usr/bin/env bash
+# The AppImage runtime mounts this read-only under /tmp/.mount_XXXXXX and runs
+# AppRun from there, so nothing may be written inside $APPDIR. anoa.sh already
+# obeys that: the only thing it creates is a symlink farm under the user's
+# cache, which is where it belongs anyway.
+HERE="$(dirname "$(readlink -f "${0}")")"
+exec "${HERE}/anoa.sh" "$@"
+APPRUN
+chmod +x "$APPDIR/AppRun"
+
+# The desktop entry. StartupWMClass matters for a Qt app: without it a window
+# manager files the window under a name the launcher does not recognise, so the
+# icon in the dock is a generic one.
+cat > "$APPDIR/anoa.desktop" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=anoa
+GenericName=Browser
+Comment=A browser you drive from a script, a terminal, or a window
+Exec=AppRun %u
+Icon=anoa
+Terminal=false
+Categories=Network;WebBrowser;Development;
+StartupWMClass=anoa
+MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;
+X-AppImage-Version=$VERSION
+DESKTOP
+
+# appimagetool wants the icon at the AppDir root under the name the .desktop
+# gives, and again under usr/share/icons for desktop integration to find it.
+if [ -f "$ROOT/docs/anoa-logo.png" ]; then
+    cp "$ROOT/docs/anoa-logo.png" "$APPDIR/anoa.png"
+    mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+    cp "$ROOT/docs/anoa-logo.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/anoa.png"
+else
+    echo "    no docs/anoa-logo.png; writing a placeholder icon" >&2
+    # A 1x1 PNG. appimagetool refuses an AppDir with no icon at all, and a
+    # missing file should not be the thing that fails a release build.
+    printf '\211PNG\r\n\032\n\0\0\0\rIHDR\0\0\0\1\0\0\0\1\10\6\0\0\0\37\25\304\211\0\0\0\nIDATx\234c\370\17\0\1\1\1\0\30\335\215\260\0\0\0\0IEND\256B`\202' \
+        > "$APPDIR/anoa.png"
+fi
+
+# Desktop integration also looks here.
+mkdir -p "$APPDIR/usr/share/applications"
+cp "$APPDIR/anoa.desktop" "$APPDIR/usr/share/applications/anoa.desktop"
+
+echo "==> fetching appimagetool"
+TOOL="$WORK/appimagetool"
+TOOL_URL="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+if [ -n "${APPIMAGETOOL:-}" ] && [ -x "${APPIMAGETOOL}" ]; then
+    TOOL="${APPIMAGETOOL}"
+else
+    curl -fsSL -o "$TOOL" "$TOOL_URL"
+    chmod +x "$TOOL"
+fi
+
+# The runtime decides where this AppImage will run at all, so it is not left to
+# the default.
+#
+# appimagetool embeds AppImageKit's own type-2 runtime, which dlopen()s
+# libfuse.so.2. Ubuntu has shipped fuse3 and NOT libfuse2 since 22.04, so that
+# runtime fails on a current Ubuntu with:
+#
+#   dlopen(): error loading libfuse.so.2
+#
+# — before a single line of anoa runs. Verified on Ubuntu 24.04: libfuse.so.2
+# absent, libfuse3.so present. Telling users to `apt install libfuse2t64` would
+# make a self-contained single file depend on a package the distro removed.
+#
+# The type2-runtime build links its FUSE statically, so it needs nothing from
+# the host but a kernel with /dev/fuse.
+RUNTIME="$WORK/runtime-x86_64"
+RUNTIME_URL="https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64"
+if [ -n "${APPIMAGE_RUNTIME:-}" ] && [ -f "${APPIMAGE_RUNTIME}" ]; then
+    RUNTIME="${APPIMAGE_RUNTIME}"
+else
+    curl -fsSL -o "$RUNTIME" "$RUNTIME_URL"
+fi
+# A truncated or HTML error page here produces an AppImage that fails with
+# something far less obvious than a download error, so it is checked now.
+if [ ! -s "$RUNTIME" ] || [ "$(head -c 4 "$RUNTIME" | tr -d '\0')" != "$(printf '\177ELF')" ]; then
+    echo "downloaded runtime is not an ELF binary: $RUNTIME_URL" >&2
+    exit 1
+fi
+chmod +x "$RUNTIME"
+
+# --appimage-extract-and-run, always: appimagetool is itself an AppImage, and
+# a build machine (a container, a CI runner) usually has no FUSE. Waiting to
+# find that out at release time is the kind of failure this flag exists for.
+echo "==> packing $OUTPUT"
+ARCH=x86_64 "$TOOL" --appimage-extract-and-run \
+    --no-appstream \
+    --runtime-file "$RUNTIME" \
+    "$APPDIR" "$OUTPUT"
+
+chmod +x "$OUTPUT"
+echo "==> $(basename "$OUTPUT")  $(du -h "$OUTPUT" | cut -f1)"


### PR DESCRIPTION
One file a Linux user downloads, `chmod +x`, and runs.

```bash
chmod +x anoa-x86_64.AppImage
./anoa-x86_64.AppImage --headless --port 9222
./anoa-x86_64.AppImage open example.com
```

Built from the portable bundle rather than by linuxdeploy, deliberately:
release.yml has already decided which libraries come from the host, and a tool
that helpfully bundles libGL, libX11 and libstdc++ would put back the
`Could not initialize GLX` this project spent a release fixing.

## Verified on real machines, not only in CI

On a stock **Ubuntu 24.04** box, running the artifact CI produced:

| | |
|---|---|
| `--version`, `help` | pass |
| headless + `open` / `get text` / `eval` / `screenshot` | pass |
| windowed with GLX under Xvfb | pass |
| `terminal` | pass |
| NSS errors in the log | **0** |

On a bare **`debian:12-slim` with nothing installed**: `--version`, the browser
and `eval` work; `open` needs `libnss3` (below).

## Three things this turned up

**The default AppImage runtime does not run on current Ubuntu.** appimagetool
embeds AppImageKit's runtime, which `dlopen()`s `libfuse.so.2` — a package
Ubuntu dropped in 22.04. On 24.04 it fails with `dlopen(): error loading
libfuse.so.2` before a line of anoa runs, which is a poor first impression for a
format whose whole promise is "just run it". The build embeds the
`type2-runtime` binary instead, which links FUSE statically.

**The bundle was shadowing the host's NSS.** Found by the AppImage smoke test on
a GitHub runner:

```
nss_util.cc(239) Error initializing NSS with a persistent database
  libsoftokn3.so: cannot open shared object file
```

Same shape as the GL and libX11 bug. `libnss3.so` is a link-time dependency so
the walk bundles it, but NSS loads `libsoftokn3`, `libfreebl3` and `libnssckbi`
at **runtime** — `ldd` never names them, so no dependency walk can package them,
and the bundled `libnss3` then shadows the host's coherent set and hunts for
modules that were never there. Chromium reads certificates through NSS, so every
HTTPS page failed while everything local kept working. **This affected the
tarball too, not just the AppImage.** NSS joins the host-first set.

It had gone unnoticed on my own test box for the dullest possible reason: that
machine happens to have `libsoftokn3.so` in `/usr/lib/x86_64-linux-gnu`, so the
bundled `libnss3` found it there. The runner does not.

**The host-first shim skipped every library without a version suffix.** The glob
was `*.so.*` — a dot after `.so`. `libGL.so.1` matched, `libnss3.so` did not, so
moving NSS into hostfirst quietly swapped a broken-HTTPS failure for a
will-not-start one:

```
anoa: error while loading shared libraries: libsmime3.so: cannot open shared object file
```

Caught on the bare container, where `--version` had worked one commit earlier.

## The smoke test that could not see its own failure

The first version of the CI step printed the page title and asserted only
`--version`, so it passed while `open` returned nothing at all — with the NSS
bug live. It fails on an empty title now. A check that cannot see the failure it
was written for is not worth running.

## Documented limits, both measured

- **No FUSE at all** (most containers) needs `APPIMAGE_EXTRACT_AND_RUN=1`, which
  unpacks the payload on every invocation: ~6 seconds per command against ~1 for
  the tarball. Right for a one-off, wrong for an agent loop — use the tarball or
  the container image there.
- **HTTPS on a host with no NSS** needs `libnss3`. `ca-certificates` alone
  changes nothing; the failure is module loading, not certificate validation.
