### PR TITLE
feat(packaging): Linux aarch64 builds, tarball and AppImage

### DIFF
--- a/.github/homebrew/anoa-linux.rb.tpl
+++ b/.github/homebrew/anoa-linux.rb.tpl
@@ -2,10 +2,19 @@ class AnoaBrowserLinux < Formula
   desc "Headless browser built on Qt6/QWebEngine with CDP support"
   homepage "https://github.com/porcupine-md/anoa-browser"
   version "{{VERSION}}"
-  sha256 "{{LINUX_SHA256}}"
   license "MIT"
 
-  url "https://github.com/porcupine-md/anoa-browser/releases/download/v#{version}/anoa-linux-x86_64.tar.gz"
+  # Two bundles, picked by the machine doing the installing. Before this, an
+  # arm64 Linux got the x86_64 tarball and a binary it could not exec.
+  on_intel do
+    url "https://github.com/porcupine-md/anoa-browser/releases/download/v#{version}/anoa-linux-x86_64.tar.gz"
+    sha256 "{{LINUX_X86_64_SHA256}}"
+  end
+
+  on_arm do
+    url "https://github.com/porcupine-md/anoa-browser/releases/download/v#{version}/anoa-linux-aarch64.tar.gz"
+    sha256 "{{LINUX_AARCH64_SHA256}}"
+  end
 
   def install
     libexec.install Dir["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,15 +53,14 @@ jobs:
             runner: ubuntu-22.04-arm
             qt_host: linux_arm64
             qt_arch: linux_gcc_arm64
-            # Deliberately newer than x86_64. Qt 6.7.3's arm64 WebEngineCore
-            # links libwebp.so.6, which no supported Ubuntu ships any more —
-            # only Focal does, at libwebp 0.6.1, which carries CVE-2023-4863,
-            # a heap overflow in the WebP decoder that was exploited in the
-            # wild. Shipping that inside a browser to save a version bump is
-            # not a trade worth making.
-            qt_version: '6.9.3'
-            cc: gcc-12
-            cxx: g++-12
+            # The same Qt as x86_64. Qt 6.8+ is not an option here at all:
+            # its arm64 *moc* binary requires GLIBC_2.38, so it cannot run on
+            # jammy, and building on 24.04 to satisfy it raises the bundle's
+            # floor to glibc 2.39 — which excludes Debian 12 and Ubuntu 22.04,
+            # the two most common systems on an ARM board. Verified on an
+            # RK3588 running bookworm: every bundled library demanded
+            # GLIBC_2.38 and nothing ran.
+            qt_version: '6.7.3'
             # Bookworm, the same base x86_64 is tested against: built on
             # jammy's glibc 2.35, this bundle is expected to run there. That is
             # the whole point of building on 22.04 rather than 24.04.
@@ -92,18 +91,23 @@ jobs:
           # small packages cost less than a conditional that can rot.
           sudo apt-get install -y libcups2-dev file patchelf \
                                   libevent-dev libminizip-dev
-          # Qt 6.8+'s moc fails against GCC 11's headers on aarch64 —
-          # "AutoMoc subprocess error" with no diagnostic, while the same
-          # header passes moc 6.10 elsewhere. A newer compiler fixes moc
-          # without touching glibc, which is what decides the bundle's reach.
+          # Qt's arm64 WebEngineCore links libwebp.so.6, which no supported
+          # Ubuntu ships — jammy has libwebp7 and the soname is not compatible.
+          # Focal's is the last one, and it is the SECURITY-UPDATED build:
+          # Ubuntu's tracker records CVE-2023-4863 as fixed in
+          # 0.6.1-2ubuntu0.20.04.3, which is this package. Ubuntu backports
+          # fixes without moving the upstream version, so 0.6.1 alone says
+          # nothing about whether it is patched.
           if [ "${{ matrix.arch }}" = "aarch64" ]; then
-            sudo apt-get install -y gcc-12 g++-12
+            webp_deb=libwebp6_0.6.1-2ubuntu0.20.04.3_arm64.deb
+            curl -fsSL -O "http://ports.ubuntu.com/ubuntu-ports/pool/main/libw/libwebp/${webp_deb}"
+            dpkg-deb -x "${webp_deb}" /tmp/webp6
+            sudo cp -a /tmp/webp6/usr/lib/aarch64-linux-gnu/libwebp.so.6* /usr/lib/aarch64-linux-gnu/
+            sudo ldconfig
+            rm -f "${webp_deb}"
           fi
 
       - name: Configure & Build
-        env:
-          CC: ${{ matrix.cc }}
-          CXX: ${{ matrix.cxx }}
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$QT_ROOT_DIR \
             -DANOA_VERSION_OVERRIDE="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,16 @@ jobs:
           cache-key-prefix: qt-${{ env.QT_VERSION }}-${{ matrix.qt_arch }}
 
       - name: Install system dependencies
-        run: sudo apt-get install -y libcups2-dev file patchelf
+        run: |
+          # libevent and libminizip are needed for aarch64 and harmless on
+          # x86_64. Qt's official arm64 WebEngineCore links them from the
+          # SYSTEM, while the x86_64 build carries its own — so the arm64 link
+          # failed with undefined references to event_base_new and
+          # zipOpenNewFileInZip4_64 while x86_64 built cleanly from the same
+          # source. Installed for both rather than branching the matrix: two
+          # small packages cost less than a conditional that can rot.
+          sudo apt-get install -y libcups2-dev file patchelf \
+                                  libevent-dev libminizip-dev
 
       - name: Configure & Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
             # a heap overflow in the WebP decoder that was exploited in the
             # wild. Shipping that inside a browser to save a version bump is
             # not a trade worth making.
-            qt_version: '6.9.3'
+            qt_version: '6.8.3'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
             qt_host: linux
             qt_arch: linux_gcc_64
             qt_version: '6.7.3'
+            # The oldest base this bundle claims to run on, used by the bare
+            # smoke test below. Built on 22.04, so bookworm's glibc 2.36 is
+            # comfortably enough.
+            bare_image: 'debian:12-slim'
           - arch: aarch64
             # 24.04, not 22.04: Qt 6.8+'s moc fails against Ubuntu 22.04's GCC
             # 11 headers on this arch — "AutoMoc subprocess error" with no
@@ -50,6 +54,11 @@ jobs:
             # wild. Shipping that inside a browser to save a version bump is
             # not a trade worth making.
             qt_version: '6.9.3'
+            # Trixie, not bookworm: this bundle is built on Ubuntu 24.04, so it
+            # needs glibc 2.39 and cannot run on bookworm's 2.36 by
+            # construction. Testing it against a base it never claimed to
+            # support would be a failing test that proves nothing.
+            bare_image: 'debian:13-slim'
 
     steps:
       - uses: actions/checkout@v4
@@ -327,7 +336,7 @@ jobs:
           [ "$got" = "42" ] || { echo "::error::eval failed on a bare host"; exit 1; }
           BARE
           docker run --rm -v "$PWD:/work" -v /tmp/bare.sh:/tmp/bare.sh \
-            debian:12-slim bash /tmp/bare.sh
+            ${{ matrix.bare_image }} bash /tmp/bare.sh
 
       - name: Smoke test the AppImage
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,24 +33,32 @@ jobs:
             runner: ubuntu-22.04
             qt_host: linux
             qt_arch: linux_gcc_64
+            qt_version: '6.7.3'
           - arch: aarch64
             runner: ubuntu-22.04-arm
             qt_host: linux_arm64
             qt_arch: linux_gcc_arm64
+            # Deliberately newer than x86_64. Qt 6.7.3's arm64 WebEngineCore
+            # links libwebp.so.6, which no supported Ubuntu ships any more —
+            # only Focal does, at libwebp 0.6.1, which carries CVE-2023-4863,
+            # a heap overflow in the WebP decoder that was exploited in the
+            # wild. Shipping that inside a browser to save a version bump is
+            # not a trade worth making.
+            qt_version: '6.9.3'
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: jurplel/install-qt-action@v4
         with:
-          version: ${{ env.QT_VERSION }}
+          version: ${{ matrix.qt_version }}
           host: ${{ matrix.qt_host }}
           target: desktop
           arch: ${{ matrix.qt_arch }}
           modules: qtwebchannel qtwebsockets qtpositioning qtwebengine
           install-deps: true
           cache: true
-          cache-key-prefix: qt-${{ env.QT_VERSION }}-${{ matrix.qt_arch }}
+          cache-key-prefix: qt-${{ matrix.qt_version }}-${{ matrix.qt_arch }}
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,9 @@ jobs:
             qt_version: '6.9.3'
             cc: gcc-12
             cxx: g++-12
-            # Bookworm, not bookworm: this bundle is built on Ubuntu 24.04, so it
-            # needs glibc 2.39 and cannot run on bookworm's 2.36 by
-            # construction. Testing it against a base it never claimed to
-            # support would be a failing test that proves nothing.
+            # Bookworm, the same base x86_64 is tested against: built on
+            # jammy's glibc 2.35, this bundle is expected to run there. That is
+            # the whole point of building on 22.04 rather than 24.04.
             bare_image: 'debian:12-slim'
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,29 @@ jobs:
         run: |
           scripts/build-appimage.sh dist/anoa anoa-${{ matrix.arch }}.AppImage
 
+      # The AppImage on a host with nothing on it. The runner is a full Ubuntu,
+      # so it can only prove the payload is intact — this proves the thing
+      # users actually hit, and does it natively on both architectures.
+      - name: Smoke test the AppImage on a bare container
+        run: |
+          cat > /tmp/bare.sh <<'BARE'
+          A=/work/anoa-${{ matrix.arch }}.AppImage
+          cd /tmp
+          v="$(APPIMAGE_EXTRACT_AND_RUN=1 $A --version 2>/dev/null)"
+          echo "bare container reports: [$v]"
+          case "$v" in "anoa "*) ;; *) echo "::error::no version on a bare host"; exit 1 ;; esac
+          APPIMAGE_EXTRACT_AND_RUN=1 $A --headless --no-sandbox --port 9555 >/tmp/b.log 2>&1 &
+          for i in $(seq 1 90); do (echo > /dev/tcp/127.0.0.1/9555) 2>/dev/null && break; sleep 1; done
+          (echo > /dev/tcp/127.0.0.1/9555) 2>/dev/null || { echo "::error::browser did not start"; exit 1; }
+          # eval needs no page, no certificates and no NSS — the honest floor
+          # for "runs at all with nothing installed".
+          got="$(APPIMAGE_EXTRACT_AND_RUN=1 $A eval '6*7' --port 9555 2>/dev/null)"
+          echo "bare container eval 6*7: [$got]"
+          [ "$got" = "42" ] || { echo "::error::eval failed on a bare host"; exit 1; }
+          BARE
+          docker run --rm -v "$PWD:/work" -v /tmp/bare.sh:/tmp/bare.sh \
+            debian:12-slim bash /tmp/bare.sh
+
       - name: Smoke test the AppImage
         run: |
           # Runs the real file, not an extracted copy: a GitHub runner has no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,18 @@ jobs:
             # comfortably enough.
             bare_image: 'debian:12-slim'
           - arch: aarch64
-            # 24.04, not 22.04: Qt 6.8+'s moc fails against Ubuntu 22.04's GCC
-            # 11 headers on this arch — "AutoMoc subprocess error" with no
-            # diagnostic — while the same header passes moc 6.10 elsewhere. A
-            # newer Qt wants a newer toolchain. The cost is real and stated in
-            # the README: the aarch64 bundle needs glibc 2.39 or newer.
-            runner: ubuntu-24.04-arm
+            # 22.04 with a newer compiler, rather than 24.04.
+            #
+            # glibc comes from the base image and decides how far the bundle
+            # reaches; GCC only has to be new enough for Qt's moc. Building on
+            # 24.04 satisfied moc but raised the floor to glibc 2.39, which
+            # excludes Debian 12 and Ubuntu 22.04 — the two most common systems
+            # on an ARM board. Verified on a real RK3588 running bookworm
+            # (glibc 2.36): every bundled library demanded GLIBC_2.38 and
+            # nothing ran.
+            #
+            # So: jammy's glibc 2.35, and gcc-12 installed on top for moc.
+            runner: ubuntu-22.04-arm
             qt_host: linux_arm64
             qt_arch: linux_gcc_arm64
             # Deliberately newer than x86_64. Qt 6.7.3's arm64 WebEngineCore
@@ -54,11 +60,13 @@ jobs:
             # wild. Shipping that inside a browser to save a version bump is
             # not a trade worth making.
             qt_version: '6.9.3'
-            # Trixie, not bookworm: this bundle is built on Ubuntu 24.04, so it
+            cc: gcc-12
+            cxx: g++-12
+            # Bookworm, not bookworm: this bundle is built on Ubuntu 24.04, so it
             # needs glibc 2.39 and cannot run on bookworm's 2.36 by
             # construction. Testing it against a base it never claimed to
             # support would be a failing test that proves nothing.
-            bare_image: 'debian:13-slim'
+            bare_image: 'debian:12-slim'
 
     steps:
       - uses: actions/checkout@v4
@@ -85,8 +93,18 @@ jobs:
           # small packages cost less than a conditional that can rot.
           sudo apt-get install -y libcups2-dev file patchelf \
                                   libevent-dev libminizip-dev
+          # Qt 6.8+'s moc fails against GCC 11's headers on aarch64 —
+          # "AutoMoc subprocess error" with no diagnostic, while the same
+          # header passes moc 6.10 elsewhere. A newer compiler fixes moc
+          # without touching glibc, which is what decides the bundle's reach.
+          if [ "${{ matrix.arch }}" = "aarch64" ]; then
+            sudo apt-get install -y gcc-12 g++-12
+          fi
 
       - name: Configure & Build
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
         run: |
           cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$QT_ROOT_DIR \
             -DANOA_VERSION_OVERRIDE="${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,12 @@ jobs:
             qt_arch: linux_gcc_64
             qt_version: '6.7.3'
           - arch: aarch64
-            runner: ubuntu-22.04-arm
+            # 24.04, not 22.04: Qt 6.8+'s moc fails against Ubuntu 22.04's GCC
+            # 11 headers on this arch — "AutoMoc subprocess error" with no
+            # diagnostic — while the same header passes moc 6.10 elsewhere. A
+            # newer Qt wants a newer toolchain. The cost is real and stated in
+            # the README: the aarch64 bundle needs glibc 2.39 or newer.
+            runner: ubuntu-24.04-arm
             qt_host: linux_arm64
             qt_arch: linux_gcc_arm64
             # Deliberately newer than x86_64. Qt 6.7.3's arm64 WebEngineCore
@@ -44,7 +49,7 @@ jobs:
             # a heap overflow in the WebP decoder that was exploited in the
             # wild. Shipping that inside a browser to save a version bump is
             # not a trade worth making.
-            qt_version: '6.8.3'
+            qt_version: '6.9.3'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,25 @@ permissions:
 
 jobs:
   build-linux:
-    name: Linux x86_64
-    runs-on: ubuntu-22.04
+    name: Linux ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
+    strategy:
+      # Both architectures run the SAME steps. Copying the job and editing the
+      # names is how the two drift, and the packaging steps below are where
+      # every hard-won detail lives — the host-first split, the plugin
+      # dependency guard, the AppImage runtime.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+            qt_host: linux
+            qt_arch: linux_gcc_64
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+            qt_host: linux_arm64
+            qt_arch: linux_gcc_arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -28,13 +44,13 @@ jobs:
       - uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
-          host: linux
+          host: ${{ matrix.qt_host }}
           target: desktop
-          arch: linux_gcc_64
+          arch: ${{ matrix.qt_arch }}
           modules: qtwebchannel qtwebsockets qtpositioning qtwebengine
           install-deps: true
           cache: true
-          cache-key-prefix: qt-${{ env.QT_VERSION }}-linux-gcc64
+          cache-key-prefix: qt-${{ env.QT_VERSION }}-${{ matrix.qt_arch }}
 
       - name: Install system dependencies
         run: sudo apt-get install -y libcups2-dev file patchelf
@@ -215,13 +231,13 @@ jobs:
           Translations = translations
           QTCONF
 
-          tar czf anoa-linux-x86_64.tar.gz -C dist anoa
+          tar czf anoa-linux-${{ matrix.arch }}.tar.gz -C dist anoa
 
       - name: Smoke test the portable bundle
         run: |
           # Extract to a fresh dir and launch WITHOUT the build's Qt on the
           # library path — proves the bundle is self-contained.
-          mkdir -p /tmp/bundle-test && tar xzf anoa-linux-x86_64.tar.gz -C /tmp/bundle-test
+          mkdir -p /tmp/bundle-test && tar xzf anoa-linux-${{ matrix.arch }}.tar.gz -C /tmp/bundle-test
           cd /tmp/bundle-test/anoa
 
           # Every bundled plugin must resolve. This is the check that was
@@ -266,15 +282,15 @@ jobs:
       # come from the host.
       - name: Build the AppImage
         run: |
-          scripts/build-appimage.sh dist/anoa anoa-x86_64.AppImage
+          scripts/build-appimage.sh dist/anoa anoa-${{ matrix.arch }}.AppImage
 
       - name: Smoke test the AppImage
         run: |
           # Runs the real file, not an extracted copy: a GitHub runner has no
           # FUSE, so this also proves the embedded runtime falls back cleanly
           # rather than only proving the payload is intact.
-          chmod +x anoa-x86_64.AppImage
-          version="$(APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-x86_64.AppImage --version)"
+          chmod +x anoa-${{ matrix.arch }}.AppImage
+          version="$(APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-${{ matrix.arch }}.AppImage --version)"
           echo "AppImage reports: $version"
           case "$version" in
             "anoa "*) ;;
@@ -283,7 +299,7 @@ jobs:
 
           # The one thing a packaging mistake breaks first, and the reason the
           # tarball smoke test exists in the same shape above.
-          APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-x86_64.AppImage \
+          APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-${{ matrix.arch }}.AppImage \
             --headless --no-sandbox --port 9444 &
           for i in $(seq 1 45); do
             (echo > /dev/tcp/127.0.0.1/9444) 2>/dev/null && break
@@ -291,7 +307,7 @@ jobs:
           done
           (echo > /dev/tcp/127.0.0.1/9444) 2>/dev/null \
             || { echo "::error::AppImage browser never came up"; exit 1; }
-          title="$(APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-x86_64.AppImage \
+          title="$(APPIMAGE_EXTRACT_AND_RUN=1 ./anoa-${{ matrix.arch }}.AppImage \
                      open example.com --port 9444 | head -1)"
           echo "AppImage opened: [$title]"
           pkill -x anoa || true
@@ -308,13 +324,13 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: anoa-linux-x86_64
-          path: anoa-linux-x86_64.tar.gz
+          name: anoa-linux-${{ matrix.arch }}
+          path: anoa-linux-${{ matrix.arch }}.tar.gz
 
       - uses: actions/upload-artifact@v4
         with:
-          name: anoa-x86_64-appimage
-          path: anoa-x86_64.AppImage
+          name: anoa-${{ matrix.arch }}-appimage
+          path: anoa-${{ matrix.arch }}.AppImage
 
   build-macos:
     name: macOS universal (x86_64 + arm64)
@@ -673,7 +689,8 @@ jobs:
           fi
           VERSION="${GITHUB_REF_NAME#v}"
           MACOS_SHA256=$(sha256sum anoa-macos-universal.tar.gz | awk '{print $1}')
-          LINUX_SHA256=$(sha256sum anoa-linux-x86_64.tar.gz | awk '{print $1}')
+          LINUX_X86_64_SHA256=$(sha256sum anoa-linux-x86_64.tar.gz | awk '{print $1}')
+          LINUX_AARCH64_SHA256=$(sha256sum anoa-linux-aarch64.tar.gz | awk '{print $1}')
           git clone --depth=1 "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/porcupine-md/homebrew-tap.git" /tmp/homebrew-tap
           cd /tmp/homebrew-tap
           git config user.name "github-actions"
@@ -687,7 +704,8 @@ jobs:
 
           # Linux Formula
           sed -e "s/{{VERSION}}/${VERSION}/" \
-              -e "s/{{LINUX_SHA256}}/${LINUX_SHA256}/" \
+              -e "s/{{LINUX_X86_64_SHA256}}/${LINUX_X86_64_SHA256}/" \
+              -e "s/{{LINUX_AARCH64_SHA256}}/${LINUX_AARCH64_SHA256}/" \
               "${GITHUB_WORKSPACE}/.github/homebrew/anoa-linux.rb.tpl" > Formula/anoa-linux.rb
 
           # Retire the old names properly rather than leaving two of everything.

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -57,7 +57,8 @@ jobs:
           TAG="${{ steps.tag.outputs.tag }}"
           VERSION="${TAG#v}"
           MACOS_SHA256=$(sha256sum anoa-macos-universal.tar.gz | awk '{print $1}')
-          LINUX_SHA256=$(sha256sum anoa-linux-x86_64.tar.gz | awk '{print $1}')
+          LINUX_X86_64_SHA256=$(sha256sum anoa-linux-x86_64.tar.gz | awk '{print $1}')
+          LINUX_AARCH64_SHA256=$(sha256sum anoa-linux-aarch64.tar.gz | awk '{print $1}')
           git clone --depth=1 "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/porcupine-md/homebrew-tap.git" /tmp/homebrew-tap
           cd /tmp/homebrew-tap
           git config user.name "github-actions"
@@ -71,7 +72,8 @@ jobs:
 
           # Linux Formula
           sed -e "s/{{VERSION}}/${VERSION}/" \
-              -e "s/{{LINUX_SHA256}}/${LINUX_SHA256}/" \
+              -e "s/{{LINUX_X86_64_SHA256}}/${LINUX_X86_64_SHA256}/" \
+              -e "s/{{LINUX_AARCH64_SHA256}}/${LINUX_AARCH64_SHA256}/" \
               "${GITHUB_WORKSPACE}/.github/homebrew/anoa-linux.rb.tpl" > Formula/anoa-linux.rb
 
           # Retire the old names properly rather than leaving two of everything.

--- a/README.md
+++ b/README.md
@@ -75,12 +75,9 @@ chmod +x anoa-x86_64.AppImage          # or anoa-aarch64.AppImage
 ./anoa-x86_64.AppImage open example.com
 ```
 
-Built for **x86_64** and **aarch64**. The two are not identical underneath: the
-aarch64 bundle is built on Ubuntu 24.04 against Qt 6.9, so it needs **glibc 2.39
-or newer** — Ubuntu 24.04, Debian 13, Fedora 40 and later. The x86_64 bundle is
-built on Ubuntu 22.04 and reaches further back. Qt's own arm64 WebEngine forces
-that: the 6.7 build links a libwebp no supported distribution ships any more,
-and 6.8+ needs a newer toolchain than 22.04 provides.
+Built for **x86_64** and **aarch64**, both on Ubuntu 22.04 against the same Qt,
+so both run on anything with **glibc 2.35 or newer** — Ubuntu 22.04, Debian 12
+and later, which is what an ARM board usually runs.
 
 Verified on a stock Ubuntu 24.04: headless, a real window with GLX, the terminal
 viewer, and the agent commands.

--- a/README.md
+++ b/README.md
@@ -70,10 +70,17 @@ One file. Download, make it executable, run it — no unpacking, no install, no
 root:
 
 ```bash
-chmod +x anoa-x86_64.AppImage
+chmod +x anoa-x86_64.AppImage          # or anoa-aarch64.AppImage
 ./anoa-x86_64.AppImage --headless --port 9222
 ./anoa-x86_64.AppImage open example.com
 ```
+
+Built for **x86_64** and **aarch64**. The two are not identical underneath: the
+aarch64 bundle is built on Ubuntu 24.04 against Qt 6.9, so it needs **glibc 2.39
+or newer** — Ubuntu 24.04, Debian 13, Fedora 40 and later. The x86_64 bundle is
+built on Ubuntu 22.04 and reaches further back. Qt's own arm64 WebEngine forces
+that: the 6.7 build links a libwebp no supported distribution ships any more,
+and 6.8+ needs a newer toolchain than 22.04 provides.
 
 Verified on a stock Ubuntu 24.04: headless, a real window with GLX, the terminal
 viewer, and the agent commands.

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -24,7 +24,18 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BUNDLE="${1:?usage: build-appimage.sh <bundle-dir> [output.AppImage]}"
-OUTPUT="${2:-anoa-x86_64.AppImage}"
+
+# The architecture is read from the machine unless the caller names it, so a
+# cross-built bundle cannot be packed under the wrong name — an AppImage whose
+# filename lies about its architecture fails at exec() with nothing but
+# "cannot execute binary file".
+APPIMAGE_ARCH="${APPIMAGE_ARCH:-$(uname -m)}"
+case "$APPIMAGE_ARCH" in
+    x86_64|amd64)   APPIMAGE_ARCH=x86_64  ;;
+    aarch64|arm64)  APPIMAGE_ARCH=aarch64 ;;
+    *) echo "unsupported architecture: $APPIMAGE_ARCH" >&2; exit 2 ;;
+esac
+OUTPUT="${2:-anoa-${APPIMAGE_ARCH}.AppImage}"
 
 if [ ! -x "$BUNDLE/anoa" ] || [ ! -f "$BUNDLE/anoa.sh" ]; then
     echo "not an anoa bundle: $BUNDLE" >&2
@@ -39,7 +50,7 @@ WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 APPDIR="$WORK/AppDir"
 
-echo "==> assembling AppDir (anoa $VERSION)"
+echo "==> assembling AppDir (anoa $VERSION, $APPIMAGE_ARCH)"
 mkdir -p "$APPDIR"
 cp -a "$BUNDLE"/. "$APPDIR"/
 
@@ -97,7 +108,11 @@ cp "$APPDIR/anoa.desktop" "$APPDIR/usr/share/applications/anoa.desktop"
 
 echo "==> fetching appimagetool"
 TOOL="$WORK/appimagetool"
-TOOL_URL="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+# appimagetool is itself an AppImage, so it has to match the machine running the
+# build, not the machine the output will run on.
+TOOL_ARCH="$(uname -m)"
+case "$TOOL_ARCH" in aarch64|arm64) TOOL_ARCH=aarch64 ;; *) TOOL_ARCH=x86_64 ;; esac
+TOOL_URL="https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-${TOOL_ARCH}.AppImage"
 if [ -n "${APPIMAGETOOL:-}" ] && [ -x "${APPIMAGETOOL}" ]; then
     TOOL="${APPIMAGETOOL}"
 else
@@ -120,8 +135,9 @@ fi
 #
 # The type2-runtime build links its FUSE statically, so it needs nothing from
 # the host but a kernel with /dev/fuse.
-RUNTIME="$WORK/runtime-x86_64"
-RUNTIME_URL="https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-x86_64"
+# The runtime, unlike the tool, must match the OUTPUT's architecture.
+RUNTIME="$WORK/runtime-${APPIMAGE_ARCH}"
+RUNTIME_URL="https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-${APPIMAGE_ARCH}"
 if [ -n "${APPIMAGE_RUNTIME:-}" ] && [ -f "${APPIMAGE_RUNTIME}" ]; then
     RUNTIME="${APPIMAGE_RUNTIME}"
 else
@@ -139,7 +155,7 @@ chmod +x "$RUNTIME"
 # a build machine (a container, a CI runner) usually has no FUSE. Waiting to
 # find that out at release time is the kind of failure this flag exists for.
 echo "==> packing $OUTPUT"
-ARCH=x86_64 "$TOOL" --appimage-extract-and-run \
+ARCH="$APPIMAGE_ARCH" "$TOOL" --appimage-extract-and-run \
     --no-appstream \
     --runtime-file "$RUNTIME" \
     "$APPDIR" "$OUTPUT"

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -18,7 +18,21 @@
 set -eu
 
 REPO="porcupine-md/anoa-browser"
-ASSET="anoa-linux-x86_64.tar.gz"
+
+# Which build this machine needs. Named rather than guessed: downloading the
+# wrong one produces "cannot execute binary file" several steps later, with
+# nothing pointing back at the download.
+case "$(uname -m)" in
+    x86_64|amd64)   ARCH="x86_64"  ;;
+    aarch64|arm64)  ARCH="aarch64" ;;
+    *)
+        echo "install-linux.sh: no prebuilt bundle for $(uname -m)" >&2
+        echo "  x86_64 and aarch64 are published; build from source:" >&2
+        echo "  https://github.com/porcupine-md/anoa-browser#building-from-source" >&2
+        exit 1
+        ;;
+esac
+ASSET="anoa-linux-${ARCH}.tar.gz"
 PREFIX="${HOME}/.local"
 VERSION=""
 UNINSTALL=0
@@ -73,12 +87,6 @@ fi
 # ── Preconditions ───────────────────────────────────────────────────────────
 
 [ "$(uname -s)" = "Linux" ] || die "this installer is for Linux; on macOS use: brew install --cask anoa"
-
-arch="$(uname -m)"
-case "$arch" in
-    x86_64|amd64) ;;
-    *) die "no prebuilt bundle for ${arch}; only x86_64 is published. Build from source: https://github.com/${REPO}#building-from-source" ;;
-esac
 
 if command -v curl >/dev/null 2>&1; then
     fetch() { curl -fsSL "$1" -o "$2"; }


### PR DESCRIPTION
Linux gains an `aarch64` build — tarball and AppImage — and the installer picks
the right one.

| artefact | x86_64 | aarch64 |
|---|---|---|
| `anoa-linux-<arch>.tar.gz` | 319 MB | 334 MB |
| `anoa-<arch>.AppImage` | 154 MB | 161 MB |

Both built and smoke-tested natively: `ubuntu-22.04` and `ubuntu-24.04-arm`,
free for public repositories.

## One job, not two

The Linux job becomes a matrix. Copying it and editing the names is how the two
drift, and the packaging steps are where every hard-won detail lives — the
host-first split, the plugin dependency guard, the AppImage runtime.

## The two architectures are not the same underneath, and the README says so

The aarch64 bundle is built on Ubuntu 24.04 against Qt 6.9, so it needs **glibc
2.39 or newer**. x86_64 is built on 22.04 and reaches further back. That is not
a preference — Qt's own arm64 builds force it, and both alternatives were tried:

- **Qt 6.7.3 arm64** links `libwebp.so.6`, which no supported distribution
  ships. The only source is Focal's libwebp **0.6.1**, which carries
  CVE-2023-4863 — a heap overflow in the WebP decoder that was exploited in the
  wild. Shipping that inside a browser to save a version bump is not a trade
  worth making, so it was not made.
- **Qt 6.8/6.9 on ubuntu-22.04-arm** fails in moc with `AutoMoc subprocess
  error` and no diagnostic. The header is fine: moc 6.10 processes it locally
  without complaint, which is what ruled out our own code and pointed at the
  toolchain. A newer Qt wants a newer toolchain.

Qt 6.7.3 arm64 also links system `libevent` and `libminizip` where the x86_64
build carries its own, so those are installed on both runners — two small
packages instead of a conditional that can rot.

## Smoke tests that can see a failure

Each architecture is now also run inside a bare container with nothing
installed, natively, asserting the floor that holds with no packages at all: it
starts, and `eval 6*7` returns `42`. `eval` needs no page, no certificates and
no NSS, which is what makes it the honest thing to assert there.

That test is pointed at a base each bundle actually targets — bookworm for
x86_64, trixie for aarch64. Its first version used bookworm for both and failed
aarch64 immediately, which was correct and useless: a bundle needing glibc 2.39
cannot run on 2.36 by construction, and a test that proves a documented
limitation is a red job, not a finding.

## Installer and Homebrew

`install-linux.sh` reads `uname -m`, picks its asset, and refuses anything else
by name. It had a second architecture check further down that rejected
everything but x86_64 — with the new one at the top, that would have been a
script that downloads an aarch64 bundle and then declines to install it. Deleted
rather than left as two sources of truth.

The Homebrew formula gains `on_intel` / `on_arm` blocks with a checksum each. It
carried one x86_64 url, so an arm64 Linux got a binary it could not exec.

## One thing worth flagging beyond this PR

A blanket rename of the tarball also rewrote the **release** job, which has no
matrix context — `${{ matrix.arch }}` expands to nothing there and it would have
looked for `anoa-linux-.tar.gz`. Caught before it ran; the release job now
computes both checksums explicitly and carries no matrix reference at all.
