### PR TITLE
fix(cli): --tab before the verb, and --tab=t2

### DIFF
--- a/.jonggrang/progress.txt
+++ b/.jonggrang/progress.txt
@@ -466,3 +466,19 @@
   failure names ca-certificates, the next names libnss3, and neither is the
   whole list. The Dockerfile's 24 packages are the real answer, and they apply
   equally to the tarball and the AppImage.
+
+- `--tab` only worked AFTER the verb, and the README, help and core skill all
+  documented it BEFORE one. The pre-scan hands everything before the verb to the
+  browser parser, which has never heard of --tab, so the documented idiom died
+  with "Unknown option 'tab'". The five addressing options — --tab, --port,
+  --host, --token, --auth-token — are moved across the verb boundary now,
+  because they name a browser rather than describe one and mean the same thing
+  on either side. Everything else still belongs to whichever side it was typed.
+
+- takeOption did not understand --opt=value at all. QCommandLineParser accepts
+  that spelling for every browser option, so --tab=t2 looked reasonable and was
+  silently dropped: the command ran against the wrong tab and said nothing. It
+  handles both spellings now.
+
+- Reported by a user driving the CLI for real, not by any test. The suites all
+  used the after-the-verb form, which is exactly the half that worked.

--- a/src/agent/agent_cli.cpp
+++ b/src/agent/agent_cli.cpp
@@ -181,6 +181,19 @@ bool takeFlag(QStringList &args, const QString &name)
 
 QString takeOption(QStringList &args, const QString &name, const QString &fallback = QString())
 {
+    // --name=value first. QCommandLineParser accepts that spelling for every
+    // browser option, so a user who writes --port=9222 out of habit and then
+    // writes --tab=t2 has no reason to expect the second to be ignored — and
+    // ignored is what it was: the value never applied and nothing said so.
+    const QString joined = name + QLatin1Char('=');
+    for (int i = 0; i < args.size(); ++i) {
+        if (!args.at(i).startsWith(joined))
+            continue;
+        const QString value = args.at(i).mid(joined.size());
+        args.removeAt(i);
+        return value;
+    }
+
     const int i = args.indexOf(name);
     if (i < 0 || i + 1 >= args.size())
         return fallback;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,7 +146,53 @@ int main(int argc, char *argv[])
             agentVerb = QString::fromLocal8Bit(argv[i]);
             for (int j = i + 1; j < argc; ++j)
                 agentArgs << QString::fromLocal8Bit(argv[j]);
-            argc = i;
+            // Anything before the verb goes with it too, so both orders work:
+            //
+            //   anoa get text --tab t2      (always did)
+            //   anoa --tab t2 get text      (used to be "Unknown option 'tab'")
+            //
+            // The second is the form our own README, help and skill documents
+            // told agents to use, and it is what a person reaches for — `git
+            // --no-pager log` reads the same way. It failed loudly, which is
+            // better than acting on the wrong tab, but "loudly wrong" is still
+            // wrong when the documentation said to type it.
+            //
+            // Only these five are moved, and only with their value. They are
+            // the options that address a browser rather than describe one, so
+            // they mean the same thing whichever side of the verb they sit;
+            // every other flag before a verb still belongs to the browser
+            // parser. The arity problem the comment above describes is why
+            // this is a fixed list rather than a general rule.
+            for (int j = 1; j < i; ++j) {
+                // Already taken as the previous option's value.
+                if (!argv[j])
+                    continue;
+                const bool addressing =
+                    isOption(argv[j], "--tab") || isOption(argv[j], "--port")
+                    || isOption(argv[j], "--host") || isOption(argv[j], "--token")
+                    || isOption(argv[j], "--auth-token");
+                if (!addressing)
+                    continue;
+                agentArgs << QString::fromLocal8Bit(argv[j]);
+                // --opt=value carries its own value; --opt value takes the next
+                // word, which must not be left behind for the browser parser to
+                // trip over.
+                const bool joined = std::strchr(argv[j], '=') != nullptr;
+                if (!joined && j + 1 < i) {
+                    agentArgs << QString::fromLocal8Bit(argv[j + 1]);
+                    argv[j + 1] = nullptr;
+                }
+                argv[j] = nullptr;
+            }
+            // Compact what is left: parseArgs still runs on this argv, and a
+            // hole in the middle of it is not something QCommandLineParser
+            // survives.
+            int keep = 1;
+            for (int j = 1; j < i; ++j) {
+                if (argv[j])
+                    argv[keep++] = argv[j];
+            }
+            argc = keep;
             argv[argc] = nullptr;
             break;
         }

--- a/tests/e2e/agent_cli.test.js
+++ b/tests/e2e/agent_cli.test.js
@@ -534,4 +534,33 @@ describe('Agent CLI (Suite 8)', () => {
       closeExtraTabs();
     }
   });
+
+  // AGENT-29: --tab works on either side of the verb, and in both spellings.
+  //
+  // It used to work only after the verb. Everything before one was handed to
+  // the browser parser, which has never heard of --tab, so
+  // `anoa --tab t2 get text` died with "Unknown option 'tab'" — and that is
+  // the form the README, the help and the core skill all told agents to type.
+  // --tab=t2 was worse: takeOption did not understand the = spelling at all,
+  // so the value was dropped in silence and the command ran against the wrong
+  // tab.
+  it('--tab is accepted before or after the verb, joined or separate', () => {
+    anoa('eval', "document.title = 'ALPHA'");
+    const t2 = anoa('tab', 'new').out.trim();
+    anoa('eval', "document.title = 'BRAVO'", '--tab', t2);
+    try {
+      const port = String(PORT);
+      // after the verb, separate — the form that always worked
+      assert.equal(run(['eval', 'document.title', '--port', port, '--tab', t2]).out, 'BRAVO');
+      // before the verb, separate — the form the docs used and that failed
+      assert.equal(run(['--tab', t2, '--port', port, 'eval', 'document.title']).out, 'BRAVO');
+      // joined, both sides
+      assert.equal(run([`--tab=${t2}`, `--port=${port}`, 'eval', 'document.title']).out, 'BRAVO');
+      assert.equal(run(['eval', 'document.title', `--port=${port}`, `--tab=${t2}`]).out, 'BRAVO');
+      // and with no --tab at all it is still the active tab
+      assert.equal(run(['eval', 'document.title', '--port', port]).out, 'ALPHA');
+    } finally {
+      closeExtraTabs();
+    }
+  });
 });


### PR DESCRIPTION
Reported from real use, not by a test.

```
anoa get text --tab t2      # worked
anoa --tab t2 get text      # exit 1: Unknown option 'tab'
```

The second is the form the README, the `TABS` help group and the core skill all
told agents to type:

```bash
TAB=$(anoa tab new example.com)
anoa --tab "$TAB" get text
```

So the documentation described a command that could not run. Every test in the
suite happened to use the other order — exactly the half that worked.

## What changed

Five options now move across the verb boundary: `--tab`, `--port`, `--host`,
`--token`, `--auth-token`. They *address* a browser rather than describe one, so
they mean the same thing on either side of the verb. Everything else still
belongs to whichever side it was typed on — the arity problem that makes a
general rule impossible is why this is a fixed list rather than a blanket rule.

## A worse bug found while fixing it

`takeOption` never understood `--opt=value`. `QCommandLineParser` accepts that
spelling for every browser option, so `--tab=t2` looks perfectly reasonable —
and it was **dropped in silence**. The command ran against the wrong tab and
said nothing, which is worse than the loud failure above. Both spellings work
now, for every agent option.

## Covered

`AGENT-29` asserts all four combinations and the no-flag default:

| form | |
|---|---|
| `eval … --tab t2` | after, separate |
| `--tab t2 … eval` | before, separate |
| `--tab=t2 … eval` | before, joined |
| `eval … --tab=t2` | after, joined |
| no `--tab` | still the active tab |

Error paths unchanged: an unknown id still names the ids that exist, a malformed
one still exits 2.

Suite: unit 4, agent CLI e2e 32.