### PR TITLE
feat(cli): name a tab, and address it by that name

### DIFF
--- a/.jonggrang/progress.txt
+++ b/.jonggrang/progress.txt
@@ -482,3 +482,19 @@
 
 - Reported by a user driving the CLI for real, not by any test. The suites all
   used the after-the-verb form, which is exactly the half that worked.
+
+- Tab names are an ALIAS for the minted id, never a replacement. Both resolve to
+  the same tab, and isValidTabName rejects anything shaped like an id
+  (^t[1-9][0-9]*$) — without that rule, a tab named "t2" would make --tab t2
+  mean either tab depending on lookup order.
+
+- Resolution happens in four places and every one of them had to learn names:
+  the CDP client's target picker, /render/*'s ?tab=, `anoa tab select|close`, and
+  Target.* over the proxy. The subtle one is /render/*: the resolved view is
+  enough for a screenshot, but the input helpers look a tab up by ID, so the
+  query value has to be normalised to the id or a named tab takes screenshots
+  and ignores clicks.
+
+- "no browser on host:port — start one first" was printed for a browser that IS
+  running but has no such tab. Wrong advice, and it predates tab names: any
+  --tab t99 produced it. The client now flags a tab miss separately.

--- a/README.md
+++ b/README.md
@@ -399,6 +399,17 @@ anoa tab select t2                # make it the active one
 anoa tab close t2                 # the last tab cannot be closed
 ```
 
+Or name it, and stop keeping track of ids:
+
+```bash
+anoa tab new example.com --name search
+anoa --tab search get text
+```
+
+A name is an alias, not a rename: the id keeps working and `--tab` takes either.
+Names must be unique, and cannot be shaped like an id (`t2`) — that is what
+keeps `--tab t2` from ever meaning two different tabs.
+
 Every other command takes `--tab <id>` and acts on the active tab without it:
 
 ```bash

--- a/src/agent/agent_cli.cpp
+++ b/src/agent/agent_cli.cpp
@@ -98,6 +98,7 @@ public:
     }
 
     QString why() const { return m_why; }
+    bool tabNotFound() const { return m_client && m_client->tabNotFound(); }
 
     CdpResult call(const QString &method, const QJsonObject &params = QJsonObject())
     {
@@ -274,6 +275,14 @@ int cmdTab(Session &s, QStringList args, bool json)
     if (sub == QLatin1String("new")) {
         const bool isolated = takeFlag(args, QStringLiteral("--isolated"));
         const QString profile = takeOption(args, QStringLiteral("--profile"));
+        // A name an agent chooses beats an id it has to remember: t1 and t2
+        // mean nothing three commands later, "search" and "cart" do.
+        const QString name = takeOption(args, QStringLiteral("--name"));
+        if (!name.isEmpty() && !isValidTabName(name)) {
+            return fail(QStringLiteral("--name takes letters, digits, - and _ (max 32) "
+                                       "and cannot look like an id: '") + name + QLatin1Char('\''),
+                        Usage);
+        }
         // Two ways of saying "not the shared jar" that mean different things:
         // a named profile persists, an isolated one does not.
         if (isolated && !profile.isEmpty())
@@ -288,6 +297,8 @@ int cmdTab(Session &s, QStringList args, bool json)
             p[QStringLiteral("anoaProfile")] = profile;
         if (isolated)
             p[QStringLiteral("anoaIsolated")] = true;
+        if (!name.isEmpty())
+            p[QStringLiteral("anoaName")] = name;
 
         const CdpResult r = s.call(QStringLiteral("Target.createTarget"), p);
         if (!r.ok)
@@ -312,11 +323,16 @@ int cmdTab(Session &s, QStringList args, bool json)
         if (json) {
             QJsonObject o;
             o[QStringLiteral("tab")] = tabId;
+            if (!name.isEmpty())
+                o[QStringLiteral("name")] = name;
             o[QStringLiteral("targetId")] = targetId;
             out() << QString::fromUtf8(QJsonDocument(o).toJson(QJsonDocument::Compact))
                   << Qt::endl;
         } else {
-            out() << tabId << Qt::endl;
+            // The name when there is one — it is what the caller passes to
+            // --tab next, and printing the id instead would make them look it
+            // up again.
+            out() << (name.isEmpty() ? tabId : name) << Qt::endl;
         }
         return Ok;
     }
@@ -334,6 +350,7 @@ int cmdTab(Session &s, QStringList args, bool json)
                 const QJsonObject info = value.toObject();
                 QJsonObject row;
                 row[QStringLiteral("tab")] = info.value(QStringLiteral("anoaTabId"));
+                row[QStringLiteral("name")] = info.value(QStringLiteral("anoaTabName"));
                 row[QStringLiteral("active")] = info.value(QStringLiteral("attached"));
                 row[QStringLiteral("url")] = info.value(QStringLiteral("url"));
                 row[QStringLiteral("title")] = info.value(QStringLiteral("title"));
@@ -350,8 +367,11 @@ int cmdTab(Session &s, QStringList args, bool json)
             out() << info.value(QStringLiteral("anoaTabId")).toString()
                   << (info.value(QStringLiteral("attached")).toBool()
                           ? QStringLiteral(" * ")
-                          : QStringLiteral("   "))
-                  << info.value(QStringLiteral("url")).toString();
+                          : QStringLiteral("   "));
+            const QString tabName = info.value(QStringLiteral("anoaTabName")).toString();
+            if (!tabName.isEmpty())
+                out() << tabName << " ";
+            out() << info.value(QStringLiteral("url")).toString();
             const QString title = info.value(QStringLiteral("title")).toString();
             if (!title.isEmpty())
                 out() << " - " << title;
@@ -365,8 +385,10 @@ int cmdTab(Session &s, QStringList args, bool json)
             return fail(QStringLiteral("tab %1 needs an id — try: anoa tab %1 t2").arg(sub),
                         Usage);
         const QString tabId = args.first();
-        if (!isValidTabId(tabId))
-            return fail(QStringLiteral("tab takes an id like t1, not '%1'").arg(tabId), Usage);
+        if (!isValidTabId(tabId) && !isValidTabName(tabId)) {
+            return fail(QStringLiteral("tab takes an id like t1 or a name, not '%1'")
+                            .arg(tabId), Usage);
+        }
 
         // The registry speaks target ids, so the tab id is translated first —
         // and an id no tab answers to is caught here rather than upstream.
@@ -376,7 +398,8 @@ int cmdTab(Session &s, QStringList args, bool json)
             listed.result.value(QStringLiteral("targetInfos")).toArray();
         for (const QJsonValue &value : infos) {
             const QJsonObject info = value.toObject();
-            if (info.value(QStringLiteral("anoaTabId")).toString() == tabId) {
+            if (info.value(QStringLiteral("anoaTabId")).toString() == tabId
+                || info.value(QStringLiteral("anoaTabName")).toString() == tabId) {
                 targetId = info.value(QStringLiteral("targetId")).toString();
                 break;
             }
@@ -1255,12 +1278,23 @@ int runAgentCommand(const Config &config, const QString &verb, const QStringList
     // error the moment it is typed, instead of a network round trip that ends
     // in "no tab tw0".
     const QString tabId = takeOption(args, QStringLiteral("--tab"));
-    if (!tabId.isEmpty() && !isValidTabId(tabId))
-        return fail(QStringLiteral("--tab takes an id like t1, not '") + tabId + QLatin1Char('\''),
+    if (!tabId.isEmpty() && !isValidTabId(tabId) && !isValidTabName(tabId)) {
+        return fail(QStringLiteral("--tab takes an id like t1 or a name, not '")
+                        + tabId + QLatin1Char('\''),
                     Usage);
+    }
 
     Session session;
     if (!session.attach(host, port, token, 10000, tabId)) {
+        // A browser that is running but has no such tab is a different problem
+        // from no browser at all, and "start one first" is actively wrong
+        // advice for it.
+        if (session.tabNotFound()) {
+            // Discovery already printed which tabs there are; only the way out
+            // is missing.
+            err() << "      list them with:  anoa tab list --port " << port << Qt::endl;
+            return NoBrowser;
+        }
         err() << "anoa: no browser on " << host << ":" << port;
         if (!session.why().isEmpty())
             err() << " (" << session.why() << ")";

--- a/src/agent/agent_help.cpp
+++ b/src/agent/agent_help.cpp
@@ -49,11 +49,15 @@ const Group kGroups[] = {
     --tab <id>                      which tab to act on (default: the active one))"},
 
     {"tabs", "TABS  — one browser, many pages", R"(  anoa tab new [url]                open a tab, print its id
+      --name <name>                 call it something; --tab takes it after
       --profile <name>              give it its own persistent cookies
       --isolated                    give it a throwaway jar, gone with the tab
   anoa tab list                     every tab; * marks the active one
   anoa tab select <id>              make a tab the active one
   anoa tab close <id>               close a tab (the last one cannot be closed)
+
+  --tab takes an id or a name, so `--tab search` and `--tab t2` can be the same
+  tab. A name is an alias: the id keeps working.
 
   Every other command takes --tab <id> and acts on the active tab without it,
   so `anoa --tab t2 get text` reads tab 2 while tab 1 keeps doing its own work.

--- a/src/agent/agent_skill.cpp
+++ b/src/agent/agent_skill.cpp
@@ -118,6 +118,24 @@ TAB=$(anoa tab new example.com)
 anoa --tab "$TAB" get text
 ```
 
+Or name it, and skip keeping the id around at all:
+
+```bash
+anoa tab new example.com --name search
+anoa --tab search get text
+```
+
+Or give it a name and stop tracking ids:
+
+```bash
+anoa tab new example.com --name search
+anoa --tab search get text
+```
+
+A name is an alias — the id keeps working, and `--tab` takes either. Names must
+be unique and cannot look like an id (`t2`), which is what keeps `--tab t2`
+unambiguous.
+
 Without `--tab`, every command acts on the active tab, so nothing you already
 do changes. `anoa tab list` shows them all with `*` on the active one.
 
@@ -159,6 +177,7 @@ survives between commands and between processes.
 | Command | Does |
 |---|---|
 | `anoa tab new [url]` | open a tab and print its id |
+| `anoa tab new --name <name>` | name it; `--tab` takes the name afterwards |
 | `anoa tab new --profile <name>` | open it with its own persistent cookies |
 | `anoa tab new --isolated` | open it with a throwaway jar, gone with the tab |
 | `anoa tab list` | every tab; `*` marks the active one |

--- a/src/browser/anoa_browser.cpp
+++ b/src/browser/anoa_browser.cpp
@@ -161,10 +161,18 @@ int AnoaBrowser::indexOf(const QString &id) const
     return -1;
 }
 
-QString AnoaBrowser::newTab(const QUrl &url, const QString &profileName, bool isolated)
+QString AnoaBrowser::newTab(const QUrl &url, const QString &profileName, bool isolated,
+                            const QString &name)
 {
+    // A name is an alias, so it has to be unique or it is not one. Refusing
+    // here rather than overwriting: two tabs answering to "search" would make
+    // every later --tab search a coin toss.
+    if (!name.isEmpty() && !resolveTab(name).isEmpty())
+        return QString();
+
     Tab tab;
     tab.id = m_minter.next();
+    tab.name = name;
     tab.profileName = profileName;
     tab.profile = profileFor(profileName, isolated);
     tab.view = createView(tab.profile);
@@ -386,6 +394,28 @@ QString AnoaBrowser::chromiumTargetId(const QString &tabId) const
 {
     const int idx = indexOf(tabId);
     return idx < 0 ? QString() : m_tabs.at(idx).chromiumTargetId;
+}
+
+QString AnoaBrowser::resolveTab(const QString &idOrName) const
+{
+    if (idOrName.isEmpty())
+        return QString();
+    // Ids first. They are minted, unique and cannot collide with a name —
+    // isValidTabName rejects anything shaped like one — so this order is a
+    // statement of which namespace owns the string, not a tie-break.
+    if (indexOf(idOrName) >= 0)
+        return idOrName;
+    for (const Tab &tab : m_tabs) {
+        if (!tab.name.isEmpty() && tab.name == idOrName)
+            return tab.id;
+    }
+    return QString();
+}
+
+QString AnoaBrowser::nameFor(const QString &tabId) const
+{
+    const int idx = indexOf(tabId);
+    return idx < 0 ? QString() : m_tabs.at(idx).name;
 }
 
 QString AnoaBrowser::targetIdFor(const QString &tabId) const

--- a/src/browser/anoa_browser.h
+++ b/src/browser/anoa_browser.h
@@ -49,12 +49,14 @@ public:
     // TabHost. Neither profile argument given means the shared default, so a
     // login in one tab is a login everywhere — today's behaviour.
     QString newTab(const QUrl &url = QUrl(), const QString &profileName = QString(),
-                   bool isolated = false) override;
+                   bool isolated = false, const QString &name = QString()) override;
     // Refuses to close the last tab: one process still means at least one page.
     bool closeTab(const QString &id) override;
     bool selectTab(const QString &id) override;
     QStringList tabIds() const override;
     QString activeTabId() const override;
+    QString resolveTab(const QString &idOrName) const override;
+    QString nameFor(const QString &tabId) const override;
     QString targetIdFor(const QString &tabId) const override;
     QString tabIdForTargetId(const QString &targetId) const override;
     QString titleFor(const QString &tabId) const override;
@@ -120,6 +122,7 @@ private:
         QString id;
         QWebEngineView *view = nullptr;
         QWebEngineProfile *profile = nullptr;
+        QString name;        // empty unless the caller chose one
         QString profileName; // empty = the shared default
         QString chromiumTargetId;
     };

--- a/src/browser/tab_ids.cpp
+++ b/src/browser/tab_ids.cpp
@@ -15,6 +15,16 @@ bool isValidTabId(const QString &id)
     return re.match(id).hasMatch();
 }
 
+bool isValidTabName(const QString &name)
+{
+    static const QRegularExpression re(
+        QStringLiteral("\\A[A-Za-z0-9][A-Za-z0-9_-]{0,31}\\z"));
+    if (!re.match(name).hasMatch())
+        return false;
+    // A name that reads like an id would make --tab ambiguous.
+    return !isValidTabId(name);
+}
+
 QJsonArray buildTargetList(const QList<TabTargetInfo> &tabs,
                            const QString &host,
                            quint16 proxyPort)
@@ -46,6 +56,10 @@ QJsonArray buildTargetList(const QList<TabTargetInfo> &tabs,
         // them; `anoa --tab` is the reason they are here.
         entry[QStringLiteral("anoaTabId")] = tab.tabId;
         entry[QStringLiteral("anoaActive")] = tab.active;
+        // Only when there is one: an empty key would read as "named nothing"
+        // rather than "unnamed".
+        if (!tab.tabName.isEmpty())
+            entry[QStringLiteral("anoaTabName")] = tab.tabName;
 
         out.append(entry);
     }

--- a/src/browser/tab_ids.h
+++ b/src/browser/tab_ids.h
@@ -29,12 +29,21 @@ private:
 // would otherwise be two spellings of one tab.
 bool isValidTabId(const QString &id);
 
+// A name a caller chose: ^[A-Za-z0-9][A-Za-z0-9_-]{0,31}$, and never something
+// that could be read as a minted id.
+//
+// That last rule is what keeps `--tab t2` unambiguous. Allowing a tab to be
+// named "t2" would mean an id and a name could point at different tabs and the
+// same string would resolve to either, depending on lookup order.
+bool isValidTabName(const QString &name);
+
 // One tab, as the discovery document needs to see it.
 //
 // tabId is ours and stable; chromiumTargetId is the engine's and changes when a
 // page is recreated, which is the whole reason the two are kept apart.
 struct TabTargetInfo {
     QString tabId;
+    QString tabName; // empty unless the caller chose one
     QString chromiumTargetId;
     QString title;
     QString url;

--- a/src/cdp/cdp_client.cpp
+++ b/src/cdp/cdp_client.cpp
@@ -55,6 +55,7 @@ struct PageTarget {
     // anoa's own fields, absent from any other CDP endpoint — which is what
     // keeps the picker's behaviour unchanged against Chrome itself.
     QString anoaTabId;
+    QString anoaTabName;
     bool anoaActive = false;
 };
 
@@ -347,6 +348,7 @@ void CdpClient::onDiscoveryFinished(QNetworkReply *reply)
         page.url = target.value(QStringLiteral("url")).toString();
         page.socketUrl = socketUrl;
         page.anoaTabId = target.value(QStringLiteral("anoaTabId")).toString();
+        page.anoaTabName = target.value(QStringLiteral("anoaTabName")).toString();
         page.anoaActive = target.value(QStringLiteral("anoaActive")).toBool();
         pages.append(page);
     }
@@ -369,7 +371,10 @@ void CdpClient::onDiscoveryFinished(QNetworkReply *reply)
     int chosen = -1;
     if (!m_tabFilter.isEmpty()) {
         for (int i = 0; i < pages.size(); ++i) {
-            if (pages.at(i).anoaTabId == m_tabFilter) {
+            // Either the minted id or the name the caller gave it.
+            if (pages.at(i).anoaTabId == m_tabFilter
+                || (!pages.at(i).anoaTabName.isEmpty()
+                    && pages.at(i).anoaTabName == m_tabFilter)) {
                 chosen = i;
                 break;
             }
@@ -377,9 +382,17 @@ void CdpClient::onDiscoveryFinished(QNetworkReply *reply)
         if (chosen < 0) {
             QStringList known;
             for (const PageTarget &page : pages) {
-                if (!page.anoaTabId.isEmpty())
-                    known.append(page.anoaTabId);
+                if (page.anoaTabId.isEmpty())
+                    continue;
+                // Named tabs are listed by name: that is what the caller wrote
+                // down, and echoing only ids would be answering a question
+                // nobody asked.
+                known.append(page.anoaTabName.isEmpty()
+                                 ? page.anoaTabId
+                                 : page.anoaTabName + QStringLiteral(" (")
+                                       + page.anoaTabId + QStringLiteral(")"));
             }
+            m_tabNotFound = true;
             failDiscovery(QStringLiteral("no tab %1 at %2 (saw: %3)")
                               .arg(m_tabFilter, hostPort(m_requestedUrl),
                                    known.isEmpty() ? QStringLiteral("none")

--- a/src/cdp/cdp_client.h
+++ b/src/cdp/cdp_client.h
@@ -139,6 +139,10 @@ public:
     // Narrows discovery to one anoa tab. Empty means "the active one", which is
     // what every invocation without --tab asks for.
     void setTabFilter(const QString &tabId);
+    // Set when discovery reached the browser and it simply has no such tab.
+    // "no browser, start one" is the wrong advice for that, and it is the
+    // advice a bare attach failure produces.
+    bool tabNotFound() const { return m_tabNotFound; }
 
 private slots:
     void onSocketConnected();
@@ -168,6 +172,7 @@ private:
     // One line on stderr, discoveryFailed(), and (by default) exec() -> 1.
     void failDiscovery(const QString &message);
     QString m_tabFilter;
+    bool m_tabNotFound = false;
     void openSocket();
     void setState(State state, const QString &text);
     void scheduleReconnect(const QString &reason);

--- a/src/cdp/cdp_extensions.cpp
+++ b/src/cdp/cdp_extensions.cpp
@@ -144,6 +144,9 @@ QJsonObject targetInfoFor(TabHost *tabs, const QString &tabId)
     // field ignores it; `anoa tab` is the reason it is here, because the id a
     // user types is not the id Chromium mints.
     info[QStringLiteral("anoaTabId")] = tabId;
+    const QString name = tabs->nameFor(tabId);
+    if (!name.isEmpty())
+        info[QStringLiteral("anoaTabName")] = name;
     return info;
 }
 
@@ -231,6 +234,7 @@ QString CdpExtensions::handleTarget(const QJsonObject &cmd, TabHost *tabs, bool 
         // them gets the shared profile, which is what every client expects.
         const QString profileName = params.value(QStringLiteral("anoaProfile")).toString();
         const bool isolated = params.value(QStringLiteral("anoaIsolated")).toBool();
+        const QString wantName = params.value(QStringLiteral("anoaName")).toString();
 
         // A context we minted means "open it beside the tabs already there";
         // one we never issued is a mistake worth saying out loud, rather than
@@ -243,10 +247,16 @@ QString CdpExtensions::handleTarget(const QJsonObject &cmd, TabHost *tabs, bool 
                                          + contextId);
             tabId = tabs->newTabInBrowserContext(url, contextId);
         } else {
-            tabId = tabs->newTab(url, profileName, isolated);
+            tabId = tabs->newTab(url, profileName, isolated, wantName);
         }
-        if (tabId.isEmpty())
+        if (tabId.isEmpty()) {
+            // The one failure worth naming: a name already in use is a caller
+            // mistake with an obvious fix, not a browser that would not open a
+            // tab.
+            if (!wantName.isEmpty() && !tabs->resolveTab(wantName).isEmpty())
+                return cdpError(cmd, QStringLiteral("Tab name already in use: ") + wantName);
             return cdpError(cmd, QStringLiteral("Could not create target"));
+        }
 
         *deferred = true;
         const QJsonObject request = cmd;

--- a/src/cdp/tab_host.h
+++ b/src/cdp/tab_host.h
@@ -16,7 +16,11 @@ class TabHost
 public:
     virtual ~TabHost() = default;
 
-    virtual QString newTab(const QUrl &url, const QString &profileName, bool isolated) = 0;
+    // `name` is optional and, when given, becomes an alias for the minted id:
+    // both resolve to the same tab, and an agent can use whichever it finds
+    // easier to keep track of. Returns empty if the name is already taken.
+    virtual QString newTab(const QUrl &url, const QString &profileName, bool isolated,
+                           const QString &name = QString()) = 0;
     virtual bool closeTab(const QString &tabId) = 0;
     virtual bool selectTab(const QString &tabId) = 0;
 
@@ -27,6 +31,10 @@ public:
     // confused: a Chromium target id changes when a page is recreated.
     virtual QString targetIdFor(const QString &tabId) const = 0;
     virtual QString tabIdForTargetId(const QString &targetId) const = 0;
+
+    // An id or a name to the id it means, or empty for neither.
+    virtual QString resolveTab(const QString &idOrName) const = 0;
+    virtual QString nameFor(const QString &tabId) const = 0;
 
     virtual QString titleFor(const QString &tabId) const = 0;
     virtual QString urlFor(const QString &tabId) const = 0;

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -116,6 +116,7 @@ QByteArray HttpServer::rebuildTargetList(const QByteArray &rewritten,
         TabTargetInfo info;
         info.tabId = tabId;
         info.chromiumTargetId = m_browser->chromiumTargetId(tabId);
+        info.tabName = m_browser->nameFor(tabId);
         info.active = (tabId == activeId);
 
         const QJsonObject target = byTargetId.value(info.chromiumTargetId);
@@ -153,16 +154,18 @@ QWebEngineView *HttpServer::resolveRenderTab(const QUrlQuery &query, QString *ba
 {
     if (!m_browser)
         return nullptr;
-    const QString tabId = query.queryItemValue(QStringLiteral("tab"));
-    if (tabId.isEmpty())
+    const QString asked = query.queryItemValue(QStringLiteral("tab"));
+    if (asked.isEmpty())
         return m_browser->activeView();
-    if (!isValidTabId(tabId)) {
-        *badId = tabId;
+    // An id or a name — whichever the caller finds easier to keep track of.
+    if (!isValidTabId(asked) && !isValidTabName(asked)) {
+        *badId = asked;
         return nullptr;
     }
-    QWebEngineView *view = m_browser->viewFor(tabId);
+    const QString tabId = m_browser->resolveTab(asked);
+    QWebEngineView *view = tabId.isEmpty() ? nullptr : m_browser->viewFor(tabId);
     if (!view)
-        *badId = tabId;
+        *badId = asked;
     return view;
 }
 
@@ -227,7 +230,10 @@ void HttpServer::handleNewConnection()
     // that is not there gets told so — falling back to the active tab would
     // send clicks to the wrong page and look like the page was wrong.
     QWebEngineView *renderView = nullptr;
-    const QString renderTabId = query.queryItemValue(QStringLiteral("tab"));
+    // Normalised to the minted id, because the input helpers below look a tab
+    // up by id. Passing a name straight through would find the right view for
+    // a screenshot and no view at all for a click.
+    QString renderTabId;
     if (path.startsWith(QStringLiteral("/render"))) {
         QString badId;
         renderView = resolveRenderTab(query, &badId);
@@ -236,6 +242,9 @@ void HttpServer::handleNewConnection()
                          QByteArray("{\"error\":\"no tab ") + badId.toUtf8() + "\"}");
             return;
         }
+        const QString asked = query.queryItemValue(QStringLiteral("tab"));
+        if (!asked.isEmpty() && m_browser)
+            renderTabId = m_browser->resolveTab(asked);
     }
 
     // Redirect /render/ (trailing slash) to /render, preserving query string.

--- a/tests/e2e/agent_cli.test.js
+++ b/tests/e2e/agent_cli.test.js
@@ -498,7 +498,13 @@ describe('Agent CLI (Suite 8)', () => {
       assert.match(unknown.err, /t1/);
       assert.match(unknown.err, new RegExp(t2));
 
-      const malformed = anoa('get', 'text', '--tab', 'junk');
+      // "junk" is a legal NAME now, so it can only fail as an unknown tab —
+      // a malformed one has to be something no tab could ever be called.
+      const unnamed = anoa('get', 'text', '--tab', 'junk');
+      assert.notEqual(unnamed.code, 0);
+      assert.match(unnamed.err, /no tab junk/);
+
+      const malformed = anoa('get', 'text', '--tab', 'has space');
       assert.equal(malformed.code, 2);
       assert.match(malformed.err, /--tab/);
     } finally {
@@ -559,6 +565,53 @@ describe('Agent CLI (Suite 8)', () => {
       assert.equal(run(['eval', 'document.title', `--port=${port}`, `--tab=${t2}`]).out, 'BRAVO');
       // and with no --tab at all it is still the active tab
       assert.equal(run(['eval', 'document.title', '--port', port]).out, 'ALPHA');
+    } finally {
+      closeExtraTabs();
+    }
+  });
+
+  // AGENT-30: a tab can be given a name, and the name works wherever an id
+  // does. Ids like t1 and t2 mean nothing to an agent three commands later;
+  // "search" and "cart" survive the round trip.
+  it('a named tab answers to its name and to its id', () => {
+    const printed = anoa('tab', 'new', '--name', 'searchtab').out.trim();
+    try {
+      // `tab new` prints the NAME when there is one — it is what gets typed next.
+      assert.equal(printed, 'searchtab');
+
+      anoa('eval', "document.title = 'NAMED'", '--tab', 'searchtab');
+      assert.equal(anoa('eval', 'document.title', '--tab', 'searchtab').out, 'NAMED');
+
+      // The id is still a valid handle: the name is an alias, not a rename.
+      const row = JSON.parse(anoa('tab', 'list', '--json').out)
+                    .find(r => r.name === 'searchtab');
+      assert.ok(row, 'the named tab is missing from tab list');
+      assert.equal(anoa('eval', 'document.title', '--tab', row.tab).out, 'NAMED');
+
+      // select and close take a name too.
+      assert.equal(anoa('tab', 'select', 'searchtab').code, 0);
+      assert.equal(JSON.parse(anoa('tab', 'list', '--json').out)
+                     .find(r => r.active).name, 'searchtab');
+    } finally {
+      closeExtraTabs();
+    }
+  });
+
+  // AGENT-31: the rules that keep a name from becoming a second, conflicting
+  // way to say the same thing.
+  it('rejects a duplicate name, and a name shaped like an id', () => {
+    anoa('tab', 'new', '--name', 'dup');
+    try {
+      const again = anoa('tab', 'new', '--name', 'dup');
+      assert.notEqual(again.code, 0);
+      assert.match(again.err, /already in use/i);
+
+      // A tab named "t9" would make --tab t9 ambiguous forever.
+      const idish = anoa('tab', 'new', '--name', 't9');
+      assert.equal(idish.code, 2);
+      assert.match(idish.err, /--name/);
+
+      assert.equal(anoa('tab', 'new', '--name', 'has space').code, 2);
     } finally {
       closeExtraTabs();
     }

--- a/tests/unit/test_tab_ids.cpp
+++ b/tests/unit/test_tab_ids.cpp
@@ -18,6 +18,8 @@ private slots:
     void mintingNeverRecyclesAClosedId();
     void validIdsAccepted();
     void invalidIdsRejected();
+    void namesAcceptedAndRejected();
+    void targetListCarriesANameOnlyWhenThereIsOne();
     void targetListHasOneEntryPerTab();
     void targetListPointsAtTheProxyPort();
     void targetListMarksExactlyOneActiveTab();
@@ -74,6 +76,26 @@ void TestTabIds::invalidIdsRejected()
     QVERIFY(!isValidTabId(QStringLiteral("1")));
 }
 
+void TestTabIds::namesAcceptedAndRejected()
+{
+    QVERIFY(isValidTabName(QStringLiteral("search")));
+    QVERIFY(isValidTabName(QStringLiteral("cart-2")));
+    QVERIFY(isValidTabName(QStringLiteral("A_b-9")));
+    QVERIFY(isValidTabName(QString(32, QLatin1Char('a'))));
+
+    QVERIFY(!isValidTabName(QString()));
+    QVERIFY(!isValidTabName(QString(33, QLatin1Char('a'))));   // one over
+    QVERIFY(!isValidTabName(QStringLiteral("has space")));
+    QVERIFY(!isValidTabName(QStringLiteral("-leading")));      // must start alnum
+    QVERIFY(!isValidTabName(QStringLiteral("has/slash")));
+    // The rule that keeps --tab unambiguous: a name may never read as an id.
+    QVERIFY(!isValidTabName(QStringLiteral("t1")));
+    QVERIFY(!isValidTabName(QStringLiteral("t42")));
+    // ...but an id-ish string that is not a valid id is a fine name.
+    QVERIFY(isValidTabName(QStringLiteral("t0")));
+    QVERIFY(isValidTabName(QStringLiteral("tab1")));
+}
+
 static TabTargetInfo makeTab(const QString &tabId,
                              const QString &targetId,
                              bool active = false)
@@ -85,6 +107,21 @@ static TabTargetInfo makeTab(const QString &tabId,
     tab.url = QStringLiteral("https://example.com/");
     tab.active = active;
     return tab;
+}
+
+void TestTabIds::targetListCarriesANameOnlyWhenThereIsOne()
+{
+    TabTargetInfo named = makeTab(QStringLiteral("t1"), QStringLiteral("AAAA"), true);
+    named.tabName = QStringLiteral("search");
+    TabTargetInfo plain = makeTab(QStringLiteral("t2"), QStringLiteral("BBBB"));
+
+    const QJsonArray list = buildTargetList({named, plain},
+                                            QStringLiteral("127.0.0.1"), 9224);
+    QCOMPARE(list.at(0).toObject().value(QStringLiteral("anoaTabName")).toString(),
+             QStringLiteral("search"));
+    // Absent, not empty: an empty key reads as "named nothing" rather than
+    // "unnamed".
+    QVERIFY(!list.at(1).toObject().contains(QStringLiteral("anoaTabName")));
 }
 
 void TestTabIds::targetListHasOneEntryPerTab()


### PR DESCRIPTION
Asked for while driving parallel tabs: `t1` and `t2` mean nothing three
commands later, so an agent ends up keeping its own map from purpose to id.

```bash
anoa tab new example.com --name search
anoa tab new example.com --name cart
anoa --tab search get text
anoa --tab cart   get text
```

## A name is an alias, not a rename

The minted id keeps working and `--tab` takes either, so nothing that already
uses ids changes. `tab new` prints the **name** when there is one, because that
is the string that gets typed next.

Two rules stop a name becoming a second, conflicting way to say the same thing:

- **Unique.** Two tabs answering to `search` would make every later
  `--tab search` a coin toss.
- **Never shaped like an id.** A tab named `t2` would make `--tab t2` resolve to
  one tab or the other depending on lookup order — the kind of ambiguity that
  only bites under load.

## Four places resolve a tab, and all four learned names

The CDP client's target picker, `?tab=` on `/render/*`, `tab select|close`, and
`Target.*` over the proxy.

`/render/*` needed care. The resolved view is enough for a screenshot, but the
input helpers look a tab up by **id** — a name reaching them unresolved would
have produced a tab that screenshots correctly and silently ignores clicks. The
query value is normalised to the id before it gets there.

## Fixed alongside

A browser that is running but has no such tab printed:

```
anoa: no browser on 127.0.0.1:9500 (no tab tidakada ...)
      start one first:  anoa --headless --port 9500
```

The browser is right there. This predates names — any `--tab t99` produced it —
and it now reads:

```
anoa: no tab tidakada at 127.0.0.1:9500 (saw: t1, search (t2), cart (t3))
      list them with:  anoa tab list --port 9500
```

## Covered

`AGENT-30` (name works wherever an id does, and the id still works),
`AGENT-31` (duplicate rejected, id-shaped name rejected, spaces rejected), plus
unit cases for the name grammar.

`AGENT-27` changed premise rather than breaking: `junk` is a legal name now, so
it can only fail as an unknown tab, and the malformed case needs something no
tab could ever be called.

Unit 4, agent CLI e2e 34, terminal e2e 11.