### PR TITLE
fix: keep sessions — flush on signal, and persist by default

### DIFF
--- a/.jonggrang/progress.txt
+++ b/.jonggrang/progress.txt
@@ -498,3 +498,20 @@
 - "no browser on host:port — start one first" was printed for a browser that IS
   running but has no such tab. Wrong advice, and it predates tab names: any
   --tab t99 produced it. The client now flags a tab miss separately.
+
+- Sessions were lost on SIGTERM/SIGINT. Chromium writes cookies and local
+  storage lazily and flushes when the profile is destroyed; browser mode had NO
+  signal handling, so a signal killed the process before any of it reached disk.
+  `--profile work` created its directory and wrote Favicons and Session Storage
+  but never a Cookies file — a profile that looked like it was working. `anoa
+  close` was always clean, which is why nothing caught it: the documented exit
+  flushed and every other one did not.
+
+- QWebEngineProfile::defaultProfile() is OFF-THE-RECORD. With no --profile,
+  anoa kept nothing at all — log in, exit, logged out, silently. The default is
+  a persistent profile named "default" under QStandardPaths::AppDataLocation
+  now; --ephemeral asks for the old behaviour.
+
+- PRF-03 asserted that no --profile writes NO directory. That was a test
+  describing the bug as intended behaviour. It asserts the default profile
+  exists now, with a sibling case for --ephemeral.

--- a/README.md
+++ b/README.md
@@ -423,9 +423,15 @@ the active tab. `/json/list` reports one entry per tab, each carrying
 `anoaTabId` and `anoaActive` alongside the fields every CDP client already
 reads.
 
-**Cookies are shared unless you say otherwise.** A login in one tab is a login
-in all of them, which is usually what you want. Two flags change that, and they
-mean different things:
+**Logins survive between runs.** Cookies and local storage go to a profile named
+`default` under your platform's application data directory, so a browser you log
+into stays logged in the next time you start one. `--profile <name>` picks a
+different one, `--profile-dir <dir>` moves them, and `--ephemeral` keeps nothing
+at all.
+
+**Cookies are shared between tabs unless you say otherwise.** A login in one tab
+is a login in all of them, which is usually what you want. Two flags change
+that, and they mean different things:
 
 ```bash
 anoa tab new example.com --profile work   # its own cookies, kept on disk

--- a/src/agent/agent_help.cpp
+++ b/src/agent/agent_help.cpp
@@ -46,7 +46,14 @@ const Group kGroups[] = {
   Reaching a browser from an agent command:
     --port <n> / --host <h>         where it is listening (default 127.0.0.1:9222)
     --token <secret>                its bearer token, if it demands one
-    --tab <id>                      which tab to act on (default: the active one))"},
+    --tab <id>                      which tab to act on (default: the active one)
+
+  Sessions:
+    Cookies and logins are kept between runs, in a profile named "default"
+    under your platform's application data directory.
+    --profile <name>                use a different one
+    --profile-dir <dir>             keep profiles somewhere else
+    --ephemeral                     keep nothing; gone when the process ends)"},
 
     {"tabs", "TABS  — one browser, many pages", R"(  anoa tab new [url]                open a tab, print its id
       --name <name>                 call it something; --tab takes it after

--- a/src/agent/agent_skill.cpp
+++ b/src/agent/agent_skill.cpp
@@ -143,8 +143,12 @@ do changes. `anoa tab list` shows them all with `*` on the active one.
 attributes, so `@e2` in one tab names nothing in another. Snapshot the tab you
 are about to act on, with the same `--tab` you will use for the click.
 
-**Cookies are shared unless you ask otherwise.** A login in one tab is a login
-in all of them. For two accounts on one site at once:
+**Logins survive between runs.** Cookies go to a persistent profile, so you can
+log in once and use it in later commands and later sessions. `--ephemeral`
+starts a browser that keeps nothing.
+
+**Cookies are shared between tabs unless you ask otherwise.** A login in one tab
+is a login in all of them. For two accounts on one site at once:
 
 ```bash
 anoa tab new example.com --isolated       # its own cookies, gone with the tab

--- a/src/browser/anoa_browser.cpp
+++ b/src/browser/anoa_browser.cpp
@@ -10,6 +10,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QStandardPaths>
 #include <QResizeEvent>
 #include <QWheelEvent>
 #include <QJsonArray>
@@ -105,7 +106,27 @@ AnoaBrowser::AnoaBrowser(const Config &config, QWidget *parent)
     if (m_config.headless)
         qputenv("QT_QPA_PLATFORM", "offscreen");
 
-    m_profile = QWebEngineProfile::defaultProfile();
+    // A persistent profile, not Qt's default one.
+    //
+    // QWebEngineProfile::defaultProfile() is OFF-THE-RECORD: it keeps nothing.
+    // So `anoa` with no --profile logged you into a site, and logged you out
+    // again the moment the process ended — with no error and nothing on disk to
+    // suggest why. A browser you drive across separate commands is exactly the
+    // case where that is wrong.
+    //
+    // Named "default" and stored where the platform keeps application data, so
+    // it behaves like any other browser profile. --profile picks a different
+    // one; --ephemeral asks for the old off-the-record behaviour back.
+    if (m_config.ephemeral) {
+        m_profile = QWebEngineProfile::defaultProfile();
+    } else {
+        const QString base = m_config.profileDir.isEmpty()
+            ? QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+            : m_config.profileDir;
+        m_profile = new QWebEngineProfile(QStringLiteral("default"), this);
+        m_profile->setPersistentStoragePath(QDir(base).filePath(QStringLiteral("default")));
+        m_profile->setPersistentCookiesPolicy(QWebEngineProfile::ForcePersistentCookies);
+    }
 
     // No layout at all. Views are children at identical geometry and the
     // active one is raised — see the header for why hiding them is not an
@@ -316,6 +337,8 @@ QWebEngineView *AnoaBrowser::activeView() const
 
 QWebEngineProfile *AnoaBrowser::profileFor(const QString &name, bool isolated)
 {
+    // The shared profile's storage root, so a named tab profile lands beside it
+    // rather than in the working directory.
     // Off-the-record and unnamed: a fresh jar per tab, gone when the tab goes.
     // Asked for explicitly, because it is the opposite of what a browser
     // normally does with a login.
@@ -330,8 +353,11 @@ QWebEngineProfile *AnoaBrowser::profileFor(const QString &name, bool isolated)
     if (QWebEngineProfile *existing = m_profilesByName.value(name))
         return existing;
 
+    const QString base = m_config.profileDir.isEmpty()
+        ? QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+        : m_config.profileDir;
     auto *profile = new QWebEngineProfile(name, this);
-    profile->setPersistentStoragePath(QDir(m_config.profileDir).filePath(name));
+    profile->setPersistentStoragePath(QDir(base).filePath(name));
     profile->setPersistentCookiesPolicy(QWebEngineProfile::ForcePersistentCookies);
     m_profilesByName.insert(name, profile);
     return profile;
@@ -701,8 +727,11 @@ void AnoaBrowser::setupNamedProfile(const QString &name, const QString &baseDir)
     if (m_profile != QWebEngineProfile::defaultProfile())
         m_profile->deleteLater();
 
+    const QString base = baseDir.isEmpty()
+        ? QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+        : baseDir;
     m_profile = new QWebEngineProfile(name, this);
-    m_profile->setPersistentStoragePath(QDir(baseDir).filePath(name));
+    m_profile->setPersistentStoragePath(QDir(base).filePath(name));
     m_profile->setPersistentCookiesPolicy(QWebEngineProfile::ForcePersistentCookies);
 
     // Called before init() in practice, so there is usually nothing to move.

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -161,6 +161,8 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
     QCommandLineOption headlessOpt("headless", "Run in offscreen/headless mode");
     QCommandLineOption noSandboxOpt("no-sandbox", "Disable Chromium sandbox");
     QCommandLineOption profileDirOpt("profile-dir", "Base directory for browser profiles", "dir");
+    QCommandLineOption ephemeralOpt("ephemeral",
+        "Keep nothing: no cookies, no storage, gone when the process ends");
     QCommandLineOption profileNameOpt("profile", "Named profile to activate", "name");
     QCommandLineOption extensionOpt("extension", "Path to an unpacked extension directory (repeatable)", "path");
     QCommandLineOption authTokenOpt("auth-token", "Bearer token required for CDP WebSocket connections", "token");
@@ -182,6 +184,7 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
     parser.addOption(headlessOpt);
     parser.addOption(noSandboxOpt);
     parser.addOption(profileDirOpt);
+    parser.addOption(ephemeralOpt);
     parser.addOption(profileNameOpt);
     parser.addOption(extensionOpt);
     parser.addOption(authTokenOpt);
@@ -211,6 +214,8 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
         cfg.noSandbox = true;
     if (parser.isSet(profileDirOpt))
         cfg.profileDir = parser.value(profileDirOpt);
+    if (parser.isSet(ephemeralOpt))
+        cfg.ephemeral = true;
     if (parser.isSet(profileNameOpt))
         cfg.profileName = parser.value(profileNameOpt);
     if (parser.isSet(authTokenOpt))

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -8,6 +8,11 @@ struct Config {
     bool headless = false;
     bool noSandbox = false;
     QString profileDir;
+    // Opt back in to Qt's off-the-record default profile: nothing is written
+    // and nothing survives the process. The default is persistent, because a
+    // browser that forgets every login is not one you can drive across
+    // commands.
+    bool ephemeral = false;
     QString profileName;
     QStringList extensionPaths;
     QString authToken;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cerrno>
+#include <csignal>
 #include <cstring>
 #include <memory>
 
@@ -11,6 +12,7 @@
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
+#include <QTimer>
 
 #include "agent/agent_cli.h"
 #include "agent/agent_help.h"
@@ -363,6 +365,34 @@ int main(int argc, char *argv[])
         qCritical("Failed to bind CDP proxy to port %u (already in use?)", wsPort);
         return 1;
     }
+
+#ifndef Q_OS_WIN
+    // Ctrl-C and SIGTERM have to end in a clean Qt shutdown, or the session is
+    // lost.
+    //
+    // Chromium writes cookies and local storage lazily and flushes them when
+    // the profile is destroyed. Until this existed, a signal killed the process
+    // outright: `--profile work` created its directory, wrote Favicons and
+    // Session Storage, and never produced a Cookies file at all — so a user who
+    // logged in, stopped the browser and started it again found themselves
+    // logged out, with a profile directory that looked like it was working.
+    //
+    // `anoa close` was always clean, which is why this went unnoticed: the
+    // documented way out flushed, and every other way did not.
+    //
+    // The handler only sets a flag. Calling into Qt from a signal handler is
+    // not safe, so a timer notices it on the event loop and asks the
+    // application to quit, which unwinds main() and destroys the profile.
+    static volatile std::sig_atomic_t quitRequested = 0;
+    std::signal(SIGINT, [](int) { quitRequested = 1; });
+    std::signal(SIGTERM, [](int) { quitRequested = 1; });
+    QTimer signalPoll;
+    QObject::connect(&signalPoll, &QTimer::timeout, &app, [&app]() {
+        if (quitRequested)
+            app.quit();
+    });
+    signalPoll.start(100);
+#endif
 
     return app.exec();
 }

--- a/tests/integration/profiles.test.js
+++ b/tests/integration/profiles.test.js
@@ -48,16 +48,31 @@ describe('Profile Isolation & Cookie Tests', () => {
     expect(statA).not.toBe(statB);
   }, 40000);
 
-  // PRF-03
-  it('No --profile flag uses default profile (no named directory created)', async () => {
+  // PRF-03: with no --profile there is still a profile, and it is on disk.
+  //
+  // This asserted the opposite — that nothing was written — which described
+  // Qt's off-the-record default profile. That profile kept nothing at all, so
+  // `anoa` with no flags logged you into a site and logged you out again when
+  // the process ended, silently. The default is a persistent profile named
+  // "default" now, and --ephemeral is how you ask for the old behaviour.
+  it('with no --profile there is still a persistent default profile', async () => {
     const base = mkdtempSync(join(tmpdir(), 'anoa-default-'));
     const proc = await startBrowser([`--profile-dir=${base}`]);
     await new Promise((r) => setTimeout(r, 500));
     await stopBrowser(proc);
-    // With no --profile, no named subdirectory should be created
     const { readdirSync } = await import('fs');
-    const entries = readdirSync(base);
-    expect(entries.length).toBe(0);
+    expect(readdirSync(base)).toContain('default');
+    rmSync(base, { recursive: true, force: true });
+  }, 25000);
+
+  // PRF-03b: and --ephemeral still keeps nothing.
+  it('--ephemeral writes no profile directory at all', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'anoa-ephemeral-'));
+    const proc = await startBrowser([`--profile-dir=${base}`, '--ephemeral']);
+    await new Promise((r) => setTimeout(r, 500));
+    await stopBrowser(proc);
+    const { readdirSync } = await import('fs');
+    expect(readdirSync(base).length).toBe(0);
     rmSync(base, { recursive: true, force: true });
   }, 25000);
 


### PR DESCRIPTION
Reported after a Google login did not survive a restart. **Two separate causes**,
both of which had to go.

## Signals killed the flush

Chromium writes cookies and local storage lazily and flushes them when the
profile is destroyed. Browser mode had **no signal handling at all**, so SIGINT
and SIGTERM ended the process outright.

The result was a profile that looked like it was working:

```
--profile kerja  →  prof/kerja/Visited Links
                    prof/kerja/Session Storage
                    prof/kerja/Favicons
                    (no Cookies, no Local Storage)
```

| how it stopped | `Cookies` | session after restart |
|---|---|---|
| `pkill` (SIGTERM) | absent | **lost** |
| `anoa close` | written | survives |

`anoa close` was always clean, which is exactly why nothing caught this — the
documented way out flushed, and every other way did not.

A handler sets a flag now; a timer on the event loop turns it into `app.quit()`,
which unwinds `main()` and destroys the profile. Verified with `pkill`, the case
that used to lose everything.

## The default profile kept nothing by design

`QWebEngineProfile::defaultProfile()` is **off-the-record**. So `anoa` with no
`--profile` logged you into a site and logged you out again when the process
ended, with nothing on disk to hint why.

The default is now a persistent profile named `default` under the platform's
application data directory — how every other browser behaves.

```bash
anoa --headless --port 9222      # logins survive between runs
anoa --profile work              # a different one
anoa --profile-dir ~/x           # keep them elsewhere
anoa --ephemeral                 # keep nothing, the old behaviour
```

## A test that described the bug as intended behaviour

`PRF-03` asserted that no `--profile` writes **no** directory. That was a
faithful description of the off-the-record default — and of the bug. It asserts
the default profile exists now, with a sibling case holding `--ephemeral` to
writing nothing.

## Verified

Both directions, on the failure mode that used to lose data:

```
--profile + SIGTERM + restart   → cookie and localStorage intact
no --profile + SIGTERM + restart → cookie and localStorage intact
--ephemeral                      → nothing written, nothing kept
```

unit 4, agent CLI e2e 34, terminal 11, smoke 5, integration 94, Playwright 14,
Puppeteer 9.