### PR TITLE
fix(browser): dialogs, downloads, popups and uploads no longer fail in silence

### DIFF
--- a/.jonggrang/progress.txt
+++ b/.jonggrang/progress.txt
@@ -515,3 +515,18 @@
 - PRF-03 asserted that no --profile writes NO directory. That was a test
   describing the bug as intended behaviour. It asserts the default profile
   exists now, with a sibling case for --ephemeral.
+
+- QWebEnginePage's dialog defaults BLOCK the renderer waiting for a click that
+  never comes. One alert() killed the whole browser: every later command timed
+  out, including Target.getTargets at the browser level, and only SIGKILL got it
+  back. Any ordinary site with a confirm did it. AnoaPage answers and records
+  them now.
+
+- Qt drops what nobody accepts, silently, in three more places: downloads
+  without a downloadRequested handler, window.open without createWindow, and
+  file inputs without chooseFiles. None of them error — the page simply does
+  not work, which is far harder to diagnose than a failure.
+
+- DOM.requestNode answers out of a node map that does not exist until DOM.enable
+  and one DOM.getDocument have run. Without them it fails with an EMPTY error
+  message, which reads as "wrong element" rather than "domain asleep".

--- a/README.md
+++ b/README.md
@@ -380,6 +380,12 @@ prints one group. For agents, **`anoa skills get commands`** is the full
 reference and `anoa skills get core` is the workflow — both printed straight
 from the binary, so instructions can never drift from the CLI you have.
 
+**Uploads, downloads, dialogs and popups** are handled rather than ignored.
+`alert`/`confirm`/`prompt` are answered without blocking, `window.open` opens a
+background tab, downloads are saved (`--download-dir`), and a file input is
+filled with `anoa upload <target> <file>` — clicking one only asks for a dialog
+nobody can answer.
+
 Not implemented, so you know not to reach for them: React introspection, Web
 Vitals, accessibility audits, a credential vault, an MCP server, plugins, and
 request interception — `anoa network` observes, it cannot block or rewrite.

--- a/src/agent/agent_cli.cpp
+++ b/src/agent/agent_cli.cpp
@@ -15,6 +15,8 @@
 #include "agent/agent_help.h"
 #include "agent/agent_script.h"
 #include "agent/agent_skill.h"
+#include <QFileInfo>
+
 #include "browser/tab_ids.h"
 #include "cdp/cdp_client.h"
 #include "config/config.h"
@@ -112,24 +114,41 @@ public:
         return result;
     }
 
+    // Runtime.evaluate that keeps the OBJECT rather than its value, with the
+    // helper script installed first. DOM.requestNode needs a handle, and
+    // returnByValue would have serialised the element into a plain object and
+    // thrown the handle away.
+    CdpResult evaluateHandle(const QString &expression)
+    {
+        installScript();
+        QJsonObject params;
+        params[QStringLiteral("expression")] = expression;
+        return call(QStringLiteral("Runtime.evaluate"), params);
+    }
+
     // Runtime.evaluate with the helper script guaranteed to be installed.
     // Installing on every call rather than once is deliberate: the page may
     // have navigated since the last command, and this process has no way to
     // know that without asking. The script returns early when it is already
     // there, so the cost is a property read.
+    bool installScript()
+    {
+        if (m_installed)
+            return true;
+        QJsonObject boot;
+        boot[QStringLiteral("expression")] = agentScript();
+        boot[QStringLiteral("returnByValue")] = true;
+        const CdpResult r = call(QStringLiteral("Runtime.evaluate"), boot);
+        m_installed = r.ok;
+        return m_installed;
+    }
+
     QJsonValue evaluate(const QString &expression, QString *error)
     {
-        if (!m_installed) {
-            QJsonObject boot;
-            boot[QStringLiteral("expression")] = agentScript();
-            boot[QStringLiteral("returnByValue")] = true;
-            const CdpResult r = call(QStringLiteral("Runtime.evaluate"), boot);
-            if (!r.ok) {
-                if (error)
-                    *error = r.errorMessage;
-                return QJsonValue();
-            }
-            m_installed = true;
+        if (!installScript()) {
+            if (error)
+                *error = QStringLiteral("could not install the page helper");
+            return QJsonValue();
         }
 
         QJsonObject params;
@@ -263,6 +282,78 @@ void printSnapshot(const QJsonObject &snap)
 // `anoa tab ...` acts on the BROWSER, not on a page: every subcommand is a
 // Target.* call the proxy answers from the tab registry, whichever page this
 // client happens to be attached to. That is why nothing here honours --tab.
+// `anoa upload <target> <file...>` — put files into a file input.
+//
+// Clicking one does nothing useful: the click asks the browser for a file
+// dialog, and there is nobody to answer it. DOM.setFileInputFiles hands the
+// files straight to the element and fires the change event the page is
+// listening for, which is what Playwright and Puppeteer do underneath their
+// own upload helpers.
+int cmdUpload(Session &s, QStringList args, bool json)
+{
+    if (args.size() < 2) {
+        return fail(QStringLiteral("upload needs a target and a file — "
+                                   "try: anoa upload @e2 ./report.pdf"),
+                    Usage);
+    }
+    const QString target = args.takeFirst();
+
+    QJsonArray files;
+    for (const QString &path : args) {
+        const QFileInfo info(path);
+        if (!info.exists() || !info.isFile())
+            return fail(QStringLiteral("no such file: %1").arg(path));
+        // Chromium resolves these in the browser process, which has its own
+        // working directory; a relative path would land somewhere else.
+        files.append(info.absoluteFilePath());
+    }
+
+    // The element, as an object the DOM domain can turn into a node id. This
+    // goes through __anoa.resolve so a ref (@e2) works exactly as a selector
+    // does, rather than upload being the one command that only takes CSS.
+    QString why;
+    Q_UNUSED(why)
+    const CdpResult handle =
+        s.evaluateHandle(QStringLiteral("__anoa.resolve(%1)").arg(jsString(target)));
+    const QString objectId =
+        handle.result.value(QStringLiteral("result")).toObject()
+              .value(QStringLiteral("objectId")).toString();
+    if (objectId.isEmpty())
+        return fail(QStringLiteral("no element for %1").arg(target));
+
+    // DOM.requestNode answers out of the node map, and the map does not exist
+    // until the domain has been enabled and the document walked once. Without
+    // these two it fails with an empty error, which reads like the element was
+    // wrong rather than the domain being asleep.
+    s.call(QStringLiteral("DOM.enable"));
+    s.call(QStringLiteral("DOM.getDocument"));
+
+    const CdpResult node = s.call(QStringLiteral("DOM.requestNode"),
+                                  QJsonObject{{QStringLiteral("objectId"), objectId}});
+    const int nodeId = node.result.value(QStringLiteral("nodeId")).toInt();
+    if (!node.ok || nodeId == 0)
+        return fail(QStringLiteral("could not address %1: %2").arg(target, node.errorMessage));
+
+    const CdpResult set = s.call(QStringLiteral("DOM.setFileInputFiles"),
+                                 QJsonObject{{QStringLiteral("nodeId"), nodeId},
+                                             {QStringLiteral("files"), files}});
+    if (!set.ok) {
+        // The error Chromium gives for a non-input element is worth passing on
+        // rather than flattening: "Node is not a file input element".
+        return fail(QStringLiteral("upload failed: %1").arg(set.errorMessage));
+    }
+
+    if (json) {
+        QJsonObject o;
+        o[QStringLiteral("target")] = target;
+        o[QStringLiteral("files")] = files;
+        out() << QString::fromUtf8(QJsonDocument(o).toJson(QJsonDocument::Compact)) << Qt::endl;
+    } else {
+        out() << "uploaded " << files.size() << " file(s) to " << target << Qt::endl;
+    }
+    return Ok;
+}
+
 int cmdTab(Session &s, QStringList args, bool json)
 {
     static const QString kUsage =
@@ -1246,6 +1337,7 @@ bool isAgentCommand(const QString &verb)
         QStringLiteral("set"),    QStringLiteral("find"),     QStringLiteral("console"),
         QStringLiteral("errors"), QStringLiteral("network"),  QStringLiteral("mouse"),
         QStringLiteral("close"),  QStringLiteral("tab"),
+        QStringLiteral("upload"),
     };
     return verbs.contains(verb);
 }
@@ -1305,6 +1397,8 @@ int runAgentCommand(const Config &config, const QString &verb, const QStringList
 
     if (verb == QStringLiteral("tab"))
         return cmdTab(session, args, json);
+    if (verb == QStringLiteral("upload"))
+        return cmdUpload(session, args, json);
     if (verb == QStringLiteral("open") || verb == QStringLiteral("goto"))
         return cmdOpen(session, args, json);
     if (verb == QStringLiteral("snapshot"))

--- a/src/agent/agent_help.cpp
+++ b/src/agent/agent_help.cpp
@@ -104,6 +104,7 @@ const Group kGroups[] = {
     {"interact", "INTERACT", R"(  anoa click <target>               click, hit-tested — fails if something covers it
   anoa fill <target> <text>         set a field's value and fire input/change
   anoa type <text>                  type into whatever has focus
+  anoa upload <target> <file...>    put files into a file input
   anoa press <key>                  Enter, Tab, Escape, ArrowDown, …
   anoa scroll [--up] [--by <px>]    scroll the page
   anoa scroll --top | --bottom      jump to either end

--- a/src/agent/agent_skill.cpp
+++ b/src/agent/agent_skill.cpp
@@ -155,6 +155,26 @@ anoa tab new example.com --isolated       # its own cookies, gone with the tab
 anoa tab new example.com --profile work   # its own cookies, kept on disk
 ```
 
+## Things a page does that used to fail quietly
+
+`alert`, `confirm` and `prompt` are answered and recorded rather than shown:
+confirm returns true, prompt returns the page's own default. Nothing blocks.
+
+`window.open` and `target=_blank` open a real background tab — `anoa tab list`
+shows it, and the tab you were driving stays active.
+
+Downloads are accepted and saved. `--download-dir` says where.
+
+Clicking a file input opens a dialog nobody can answer, so upload the file
+directly instead:
+
+```bash
+anoa upload @e2 ./report.pdf
+```
+
+That fires the page's `change` handler, which is what a form validating on
+change is waiting for.
+
 ## Watching it happen
 
 `anoa terminal` renders the live page in the terminal and forwards clicks and
@@ -244,6 +264,7 @@ more. Use `snapshot` when you need to *act*, `get text` when you need to *read*.
 | `anoa click <target>` | click, hit-tested — refuses if something covers it |
 | `anoa fill <target> <text>` | write into a field and fire input/change |
 | `anoa type <text>` | type into whatever has focus |
+| `anoa upload <target> <file...>` | put files into a file input |
 | `anoa press <key>` | Enter, Tab, Escape, ArrowDown, … |
 | `anoa scroll [--up] [--by <px>]` | scroll the page |
 | `anoa scroll --top` / `--bottom` | jump to either end |

--- a/src/browser/anoa_browser.cpp
+++ b/src/browser/anoa_browser.cpp
@@ -1,5 +1,7 @@
 #include "anoa_browser.h"
 
+#include <functional>
+
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
@@ -18,6 +20,7 @@
 #include <QJsonObject>
 #include <QTimer>
 #include <QWebEngineCookieStore>
+#include <QWebEngineDownloadRequest>
 #include <QWebEnginePage>
 #include <QWebEngineProfile>
 #include <QWebEngineScript>
@@ -41,6 +44,34 @@ public:
     {
     }
 
+    // What the page asked and what it was told, newest last. An agent cannot
+    // see a dialog it never gets to answer, so the answer is recorded instead.
+    struct DialogRecord {
+        QString kind; // alert | confirm | prompt | beforeunload
+        QString message;
+        QString answer;
+    };
+    QList<DialogRecord> takeDialogs()
+    {
+        QList<DialogRecord> out;
+        out.swap(m_dialogs);
+        return out;
+    }
+    void setConfirmAnswer(bool accept) { m_confirmAnswer = accept; }
+    void setPromptAnswer(const QString &text) { m_promptAnswer = text; }
+
+    // How this page opens another one. Set by the registry, because a page
+    // cannot make a tab on its own and src/browser is the only place that
+    // knows how.
+    void setTabOpener(std::function<QWebEnginePage *()> opener)
+    {
+        m_openTab = std::move(opener);
+    }
+    // Files handed to the next <input type=file> that asks. Armed ahead of the
+    // click, because the click is what triggers the request and there is
+    // nobody to answer a file dialog.
+    void armFiles(const QStringList &paths) { m_armedFiles = paths; }
+
 protected:
     void javaScriptConsoleMessage(JavaScriptConsoleMessageLevel level, const QString &message,
                                   int lineNumber, const QString &sourceId) override
@@ -50,8 +81,84 @@ protected:
         QWebEnginePage::javaScriptConsoleMessage(level, message, lineNumber, sourceId);
     }
 
+    // The default implementations put a modal dialog on screen and block the
+    // renderer until somebody clicks it. Nobody ever does here: headless has no
+    // screen, and the agent driving the browser is on the other side of a
+    // socket the renderer has stopped serving.
+    //
+    // One alert() therefore killed the browser outright — not the tab, the
+    // whole process. Every later command, down to Target.getTargets at the
+    // browser level, timed out, and the only way back was SIGKILL. Any ordinary
+    // site that pops a confirm did it.
+    //
+    // So they answer immediately and record what happened, which is also what
+    // an automated browser is expected to do: Chrome's own headless mode
+    // dismisses dialogs unless a client has subscribed to Page.javascriptDialog.
+    void javaScriptAlert(const QUrl &securityOrigin, const QString &msg) override
+    {
+        Q_UNUSED(securityOrigin)
+        m_dialogs.append({QStringLiteral("alert"), msg, QString()});
+    }
+
+    bool javaScriptConfirm(const QUrl &securityOrigin, const QString &msg) override
+    {
+        Q_UNUSED(securityOrigin)
+        m_dialogs.append({QStringLiteral("confirm"), msg,
+                          m_confirmAnswer ? QStringLiteral("true") : QStringLiteral("false")});
+        return m_confirmAnswer;
+    }
+
+    bool javaScriptPrompt(const QUrl &securityOrigin, const QString &msg,
+                          const QString &defaultValue, QString *result) override
+    {
+        Q_UNUSED(securityOrigin)
+        // The page's own default unless one was set, so a prompt that offers a
+        // sensible value gets it rather than an empty string.
+        const QString answer = m_promptAnswer.isNull() ? defaultValue : m_promptAnswer;
+        if (result)
+            *result = answer;
+        m_dialogs.append({QStringLiteral("prompt"), msg, answer});
+        return true;
+    }
+
+    // window.open and target=_blank. Without this, Qt drops the request and
+    // returns nothing — the page sees a null window, or worse, sees a truthy
+    // one and waits for a document that never arrives. Now it becomes a real
+    // background tab, which is what a browser with tabs should do with it.
+    QWebEnginePage *createWindow(WebWindowType type) override
+    {
+        Q_UNUSED(type)
+        if (!m_openTab)
+            return nullptr;
+        return m_openTab();
+    }
+
+    // A file input asked for files. The default puts a native dialog on screen
+    // — invisible in headless, and unanswerable by an agent either way, so the
+    // upload simply never happened.
+    QStringList chooseFiles(FileSelectionMode mode, const QStringList &oldFiles,
+                            const QStringList &acceptedMimeTypes) override
+    {
+        Q_UNUSED(oldFiles)
+        Q_UNUSED(acceptedMimeTypes)
+        if (m_armedFiles.isEmpty())
+            return QStringList();
+        // One arming, one use: leaving them set would attach the same file to
+        // every later upload on the page.
+        QStringList files;
+        files.swap(m_armedFiles);
+        if (mode == FileSelectOpen && files.size() > 1)
+            files = QStringList{files.first()};
+        return files;
+    }
+
 private:
     bool m_silenceConsole;
+    std::function<QWebEnginePage *()> m_openTab;
+    QStringList m_armedFiles;
+    QList<DialogRecord> m_dialogs;
+    bool m_confirmAnswer = true;   // accept: the common intent when driving
+    QString m_promptAnswer;        // null = use the page's default
 };
 
 } // namespace
@@ -133,10 +240,52 @@ AnoaBrowser::AnoaBrowser(const Config &config, QWidget *parent)
     // option.
 }
 
+void AnoaBrowser::acceptDownloadsOn(QWebEngineProfile *profile)
+{
+    if (!profile || m_downloadWired.contains(profile))
+        return;
+    m_downloadWired.insert(profile);
+    // Qt cancels a download nobody accepts, silently. A page that offers a file
+    // therefore did nothing at all, with no error anywhere to say why.
+    connect(profile, &QWebEngineProfile::downloadRequested, this,
+            [this](QWebEngineDownloadRequest *item) {
+                if (!item)
+                    return;
+                const QString dir = m_config.downloadDir.isEmpty()
+                    ? QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)
+                    : m_config.downloadDir;
+                QDir().mkpath(dir);
+                item->setDownloadDirectory(dir);
+                item->accept();
+                connect(item, &QWebEngineDownloadRequest::isFinishedChanged, this, [this, item]() {
+                    if (!item->isFinished())
+                        return;
+                    emit downloadFinished(QDir(item->downloadDirectory())
+                                              .filePath(item->downloadFileName()),
+                                          item->state()
+                                              == QWebEngineDownloadRequest::DownloadCompleted);
+                });
+            });
+}
+
 QWebEngineView *AnoaBrowser::createView(QWebEngineProfile *profile)
 {
     auto *view = new QWebEngineView(this);
-    view->setPage(new AnoaPage(m_config.terminalMode, profile, view));
+    acceptDownloadsOn(profile);
+    auto *page = new AnoaPage(m_config.terminalMode, profile, view);
+    // A popup becomes a background tab on the same profile: it is the same
+    // session the opener belongs to, and putting it in front would interrupt
+    // whoever is driving the active tab.
+    page->setTabOpener([this, profile]() -> QWebEnginePage * {
+        Tab tab;
+        tab.id = m_minter.next();
+        tab.profile = profile;
+        tab.view = createView(profile);
+        m_profileUsers[profile] += 1;
+        const QString id = finishNewTab(tab, QUrl());
+        return id.isEmpty() ? nullptr : pageFor(id);
+    });
+    view->setPage(page);
 
     // Every view reports through the same three signals, filtered to whichever
     // tab is active. A filter rather than connect/disconnect on every switch:

--- a/src/browser/anoa_browser.h
+++ b/src/browser/anoa_browser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QHash>
+#include <QSet>
 #include <QList>
 #include <QNetworkCookie>
 #include <QPoint>
@@ -102,6 +103,7 @@ public:
     bool sendKey(const QString &keyName, const QString &tabId = QString());
 
 signals:
+    void downloadFinished(const QString &path, bool ok);
     void tabCreated(const QString &id);
     void tabClosed(const QString &id);
     void tabActivated(const QString &id);
@@ -142,6 +144,9 @@ private:
     // Asynchronous by construction: a seam is crossed by signals, never by a
     // blocking call, and the answer does not exist yet when the tab is created.
     void resolveTargetId(const QString &tabId, int attempt);
+    // Once per profile: a second connection would accept the same download
+    // twice and race over the file name.
+    void acceptDownloadsOn(QWebEngineProfile *profile);
 
     Config m_config;
     QWebEngineProfile *m_profile;
@@ -155,6 +160,7 @@ private:
     // A CDP browser context is a profile as a client sees it. Minted per
     // profile OBJECT, so two tabs sharing a profile report one id and an
     // isolated tab reports its own.
+    QSet<QWebEngineProfile *> m_downloadWired;
     QHash<QWebEngineProfile *, QString> m_contextIds;
     int m_nextContextId = 0;
     QString m_activeTabId;

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -161,6 +161,8 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
     QCommandLineOption headlessOpt("headless", "Run in offscreen/headless mode");
     QCommandLineOption noSandboxOpt("no-sandbox", "Disable Chromium sandbox");
     QCommandLineOption profileDirOpt("profile-dir", "Base directory for browser profiles", "dir");
+    QCommandLineOption downloadDirOpt("download-dir",
+        "Where downloads are saved (default: the platform Downloads folder)", "dir");
     QCommandLineOption ephemeralOpt("ephemeral",
         "Keep nothing: no cookies, no storage, gone when the process ends");
     QCommandLineOption profileNameOpt("profile", "Named profile to activate", "name");
@@ -184,6 +186,7 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
     parser.addOption(headlessOpt);
     parser.addOption(noSandboxOpt);
     parser.addOption(profileDirOpt);
+    parser.addOption(downloadDirOpt);
     parser.addOption(ephemeralOpt);
     parser.addOption(profileNameOpt);
     parser.addOption(extensionOpt);
@@ -214,6 +217,8 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
         cfg.noSandbox = true;
     if (parser.isSet(profileDirOpt))
         cfg.profileDir = parser.value(profileDirOpt);
+    if (parser.isSet(downloadDirOpt))
+        cfg.downloadDir = parser.value(downloadDirOpt);
     if (parser.isSet(ephemeralOpt))
         cfg.ephemeral = true;
     if (parser.isSet(profileNameOpt))

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -13,6 +13,8 @@ struct Config {
     // browser that forgets every login is not one you can drive across
     // commands.
     bool ephemeral = false;
+    // Where accepted downloads land. Empty = the platform's Downloads folder.
+    QString downloadDir;
     QString profileName;
     QStringList extensionPaths;
     QString authToken;

--- a/tests/e2e/agent_cli.test.js
+++ b/tests/e2e/agent_cli.test.js
@@ -11,7 +11,7 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn, spawnSync } from 'node:child_process';
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -614,6 +614,62 @@ describe('Agent CLI (Suite 8)', () => {
       assert.equal(anoa('tab', 'new', '--name', 'has space').code, 2);
     } finally {
       closeExtraTabs();
+    }
+  });
+
+  // AGENT-32: the hooks a page needs to not fail silently.
+  //
+  // None of these existed. A single alert() wedged the whole browser — not the
+  // tab, the process: every later command timed out, including Target.* at the
+  // browser level, and only SIGKILL got it back. Downloads and window.open were
+  // dropped without a word.
+  it('a dialog does not wedge the browser, and answers sensibly', () => {
+    assert.equal(anoa('eval', "alert('hi'); 'past the alert'").out, 'past the alert');
+    // The tell-tale of the old bug: everything after an alert timed out.
+    assert.equal(anoa('eval', '1 + 1').out, '2');
+    assert.equal(anoa('eval', "String(confirm('ok?'))").out, 'true');
+    assert.equal(anoa('eval', "prompt('name?', 'fallback')").out, 'fallback');
+    assert.equal(anoa('status').code, 0);
+  });
+
+  // AGENT-33
+  it('window.open becomes a real background tab', () => {
+    try {
+      const before = JSON.parse(anoa('tab', 'list', '--json').out).length;
+      anoa('eval', "window.open('https://example.net')");
+      // The tab exists, and the caller's tab is still the active one.
+      const rows = JSON.parse(anoa('tab', 'list', '--json').out);
+      assert.equal(rows.length, before + 1);
+      assert.equal(rows.find(r => r.active).tab, 't1');
+    } finally {
+      closeExtraTabs();
+    }
+  });
+
+  // AGENT-34: clicking a file input asks for a dialog nobody can answer, so
+  // the files are handed to the element directly — and the page's change
+  // handler has to see them, or a form that validates on change never knows.
+  it('upload puts files into an input and fires change', () => {
+    const tmp = resolve(root, 'build', 'agent-upload.txt');
+    writeFileSync(tmp, 'payload');
+    try {
+      anoa('eval', "document.body.innerHTML = '<input id=up type=file>';" +
+                   " window.__seen = '';" +
+                   " document.getElementById('up').onchange = e => window.__seen = e.target.files[0].name; 'ready'");
+      assert.equal(anoa('upload', '#up', tmp).code, 0);
+      assert.equal(anoa('eval', "document.getElementById('up').files.length").out, '1');
+      assert.equal(anoa('eval', 'window.__seen').out, 'agent-upload.txt');
+
+      // A target that is not a file input says so rather than half-working.
+      const wrong = anoa('upload', 'body', tmp);
+      assert.notEqual(wrong.code, 0);
+      assert.match(wrong.err, /file input/i);
+
+      const missing = anoa('upload', '#up', '/no/such/file');
+      assert.notEqual(missing.code, 0);
+      assert.match(missing.err, /no such file/i);
+    } finally {
+      rmSync(tmp, { force: true });
     }
   });
 });


### PR DESCRIPTION
Reported as "cannot upload a file". Upload turned out to be the smallest part:
**none** of the hooks a page needs were implemented, and Qt's behaviour without
them is to drop the request without a word.

| what a page does | before | now |
|---|---|---|
| `alert` / `confirm` / `prompt` | **wedges the whole browser** | answered and recorded |
| download a file | dropped silently | saved (`--download-dir`) |
| `window.open`, `target=_blank` | dropped, returns truthy | opens a background tab |
| click a file input | nothing happens | `anoa upload` fills it |
| `DOM.setFileInputFiles` (CDP) | worked | unchanged |

## The one that mattered most

`QWebEnginePage::javaScriptAlert` and friends put a modal on screen and **block
the renderer** until somebody clicks it. Headless has no screen, and the agent
is on the far side of a socket the renderer has stopped serving.

So one `alert()` ended the session — not the tab, the process:

```
anoa eval "alert(1)"     → ok
anoa eval "1+1"          → Runtime.evaluate timed out after 10000 ms
anoa status              → timed out
anoa tab list            → Target.getTargets timed out
```

Process alive, completely unusable, recoverable only with SIGKILL. Any ordinary
site with a confirm dialog did this.

They answer immediately now and record what was asked and what was answered —
`confirm` accepts, `prompt` returns the page's own default. That is also what
Chrome's headless mode does.

## Uploads

Clicking a file input asks the browser for a dialog nobody can answer, so the
files go straight to the element:

```bash
anoa upload @e2 ./report.pdf      # a ref
anoa upload "#file" a.png b.png   # or a selector
```

It goes through `DOM.setFileInputFiles`, the same mechanism Playwright and
Puppeteer use, and **fires the page's `change` handler** — which is what a form
validating on change is waiting for. `chooseFiles` is overridden as well, so a
headed run cannot pop a dialog nobody will close.

## Found while building it

`DOM.requestNode` answers out of a node map that does not exist until
`DOM.enable` and one `DOM.getDocument` have run. Without them it fails with an
**empty** error message, which reads as "wrong element" rather than "domain
asleep".

## Deliberately unchanged

Certificate errors. A driven browser that silently accepts a bad certificate is
one you cannot use to check a certificate, and a page that fails to load is a
visible, debuggable outcome.

## Covered

`AGENT-32` (a dialog does not wedge the browser), `AGENT-33` (popup becomes a
background tab, the driven tab stays active), `AGENT-34` (upload fills the input
and fires change; wrong target and missing file both fail clearly).

unit 4, agent CLI 37, terminal 11, smoke 5, integration 95, Playwright 14,
Puppeteer 9.