### PR TITLE
chore(release): 0.10.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(anoa VERSION 0.10.0 LANGUAGES CXX)
+project(anoa VERSION 0.10.1 LANGUAGES CXX)
 
 # CI injects the git tag here so the tag is the single source of truth for the
 # version — CMakeLists.txt never needs a manual bump for releases. The value


### PR DESCRIPTION
Patch release. CI-only change plus one shutdown-ordering fix; see #16.

Release dry-run on this branch: all four platform builds green, AppImage smoke tests pass on x86_64 and aarch64 including the bare-container run.