### PR TITLE
feat(render): make the live view interactive and embeddable

### DIFF
--- a/.jonggrang/progress.txt
+++ b/.jonggrang/progress.txt
@@ -554,3 +554,11 @@
 - The old page substituted the server's auth token into the HTML, so every
   authenticated GET /render returned a document with the secret in it. The new
   page is static and reads the token from its own query string instead.
+- Menulis contoh embed (examples/embed/) langsung membongkar celah yang tak
+  terlihat dari uji endpoint: --embed-origin mengizinkan sebuah origin
+  menyematkan DAN mengemudikan browser, tapi fetch ke /json/list tetap ditolak
+  karena tak ada header CORS. Jadi aplikasi tuan rumah bisa menampilkan view dan
+  tidak bisa menggambar bilah tab di sekelilingnya — yang justru sebagian besar
+  alasan orang menyematkannya. CORS kini memakai daftar origin yang sama.
+  Pelajarannya: menulis contoh yang benar-benar dijalankan menemukan hal yang
+  tidak ditemukan suite endpoint, karena suite memanggil server tanpa origin.

--- a/.jonggrang/progress.txt
+++ b/.jonggrang/progress.txt
@@ -562,3 +562,20 @@
   alasan orang menyematkannya. CORS kini memakai daftar origin yang sama.
   Pelajarannya: menulis contoh yang benar-benar dijalankan menemukan hal yang
   tidak ditemukan suite endpoint, karena suite memanggil server tanpa origin.
+- /render/scroll tidak pernah bekerja di macOS, dan tak ada satu tes pun yang
+  memeriksa halaman benar-benar bergerak — endpoint menjawab "scrolled" dan
+  halaman diam. macOS tak punya wheel tanpa fase: Qt mengirimnya sebagai gestur,
+  dan QtWebEngine memetakan Qt::NoScrollPhase ke fase Blink yang dibuang
+  Chromium, jadi peristiwanya diposting, diterima, lalu hilang sebelum sampai ke
+  halaman. Linux/aarch64 benar sejak dulu — dibuktikan dengan menjalankan rilis
+  v0.10.1 di papan RK3588, yang scroll-nya jalan. Pelajaran: menjalankan suite
+  hanya di satu OS tidak akan pernah menemukan ini.
+- Inspect element ternyata sudah tersedia penuh dan tak punya jalan masuk:
+  frontend DevTools Chromium disajikan di port+1 dan berbicara ke halaman lewat
+  proxy CDP di port+2, persis yang sudah disebut webSocketDebuggerUrl. Yang
+  ditambahkan hanya tombol.
+- Dua kelemahan harness tes yang membuat angka menyesatkan: vitest melaporkan
+  beforeAll yang melempar sebagai "skipped", bukan "failed", sehingga satu berkas
+  penuh (10 kasus pdf_handler) hilang di balik "0 gagal"; dan /json/list sah-sah
+  saja kosong sesaat setelah start karena id target Chromium belum diresolusi,
+  sementara startBrowser hanya menunggu port terikat.

--- a/.jonggrang/progress.txt
+++ b/.jonggrang/progress.txt
@@ -530,3 +530,27 @@
 - DOM.requestNode answers out of a node map that does not exist until DOM.enable
   and one DOM.getDocument have run. Without them it fails with an EMPTY error
   message, which reads as "wrong element" rather than "domain asleep".
+
+## feat/embeddable-live-view (2026-08-16)
+
+- /render was a 500 ms PNG poller with no input and no tabs. It is now an MJPEG
+  live view with a tab bar, a URL bar and full mouse/keyboard forwarding, served
+  from a Qt resource rather than a C++ format string.
+- Found while wiring it: /render/stream.mjpeg called browser->grab(), which
+  grabs the container and therefore whatever tab is raised. ?tab= was resolved,
+  404'd correctly for a bad id, and then ignored. Streaming a background tab
+  gave you the active one with nothing anywhere to say so.
+- Input primitives that did not exist: mouse move, separate press/release, and
+  modifiers on anything. Without them there is no hover, no drag, no text
+  selection and no Ctrl+A — the click endpoint can drive a page from a script
+  but cannot be driven by a pointer.
+- HiDPI: grab() is device pixels, the input endpoints are logical pixels. Added
+  GET /render/viewport so a client never has to guess from the image.
+- Embedding is opt-in by origin (frame-ancestors 'self' by default,
+  --embed-origin to widen). The view forwards keystrokes, so framing it is
+  handing over the session, not showing a picture of one. Verified both ways by
+  screenshotting a cross-origin host page: blocked renders Chromium's broken-
+  document icon, allowed renders the viewer.
+- The old page substituted the server's auth token into the HTML, so every
+  authenticated GET /render returned a document with the secret in it. The new
+  page is static and reads the token from its own query string instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,21 @@ tests/
 
 ## Known Gotchas
 
+- **A frame is device pixels; every input endpoint is logical pixels.**
+  `QWidget::grab()` returns a pixmap at the display's devicePixelRatio, so on a
+  HiDPI screen `/render/screenshot.png` and `/render/stream.mjpeg` are twice the
+  width of the coordinate space `/render/click` and friends speak. A client that
+  maps a click through the image it was given lands at double the intended
+  point, on a page that looks like it just ignored the click. `GET
+  /render/viewport` exists to answer this and the `X-Anoa-Viewport-*` headers
+  carry the same numbers — use one of them, never the image's own dimensions.
+
+- **Grabbing the container is not grabbing a tab.** `AnoaBrowser` is a container
+  whose active view is raised, so `browser->grab()` returns whatever is on top,
+  regardless of the `?tab=` that was resolved for the request. The MJPEG stream
+  did exactly this and so accepted `?tab=` and silently ignored it. Grab the
+  view `resolveRenderTab()` returned.
+
 - **Never tag a release without running the Release workflow on
   `workflow_dispatch` first.** It builds and smoke-tests every package and
   publishes nothing, so a broken package is caught before it reaches anyone.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ set(SOURCES
 # found by path is an icon that is sometimes missing.
 qt_add_resources(SOURCES resources/icons/anoa.qrc)
 
+# The live-view page, same reasoning: served from memory, so it cannot go
+# missing when the binary is moved or run out of an AppImage.
+qt_add_resources(SOURCES resources/viewer/viewer.qrc)
+
 # Windows reads an executable's icon from a resource compiled into it. Listed
 # only there because .rc is meaningless to the other two toolchains.
 if(WIN32)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ position survive between them, so commands chain with `&&` for free.
 
 - **A command per action, for agents** — `open`, `snapshot`, `click`, `fill`, `get`, `eval`, `wait`, `screenshot`. `snapshot` hands back refs (`@e1`, `@e2`) that later commands target, and clicks are hit-tested, so a button under a consent banner is reported rather than clicked through. `anoa help` groups them; `anoa skills get core` prints the workflow for an agent to read
 - **Speaks CDP** — connect Playwright, Puppeteer or any Chrome-compatible client, with Chrome-compatible discovery endpoints (`/json`, `/json/version`, `/json/list`) and a WebSocket proxy with session multiplexing and optional bearer-token auth
-- **Drive it over plain HTTP** — live viewer, PNG screenshots, MJPEG stream, navigation and click/scroll injection through `/render/*`, no CDP client required
+- **Drive it over plain HTTP** — an interactive live view you can drop in an `<iframe>`, PNG screenshots, MJPEG stream per tab, and full mouse/keyboard injection through `/render/*`, no CDP client required
 - **See it in your terminal** — `anoa terminal` renders the live page as ANSI or as real images in iTerm2/kitty, and forwards your clicks, scrolls and typing back to it. Point it at a running browser, at any external Chrome endpoint with `--cdp`, or at nothing at all and it hosts its own
 - **A window when you want one** — an address bar with back / forward / reload, and an auto-hiding toolbar that returns when the pointer reaches the top edge
 - **Works behind tunnels and proxies** — no Origin rejections, with `--auth-token` for access control
@@ -472,7 +472,8 @@ All endpoints share the same `--auth-token` auth as the CDP endpoints: pass the 
 
 | Method | Path | Response | Description |
 |---|---|---|---|
-| `GET` | `/render` | `text/html` | Live viewer page — auto-refreshing screenshot in the browser |
+| `GET` | `/render?tab=<id>&embed=1` | `text/html` | Live view — MJPEG stream you can click, type and drag in, with a tab bar and URL bar. `embed=1` drops the chrome for embedding; `tab=` picks the tab to drive |
+| `GET` | `/render/viewport?tab=<id>` | `application/json` | `{"width","height","dpr"}` — the logical size the input endpoints below speak. Not the frame's pixel size: frames are device pixels, so on a HiDPI display the image is `dpr`× wider than the coordinates that drive it |
 | `GET` | `/render/screenshot.png` | `image/png` | Current frame as a PNG snapshot; `X-Anoa-Viewport-Width/Height` headers carry the logical viewport size |
 | `GET` | `/render/screenshot.ppm?w=<px>&h=<px>` | `image/x-portable-pixmap` | Current frame as binary PPM (P6), scaled server-side (aspect ratio kept); `X-Anoa-Viewport-Width/Height` headers carry the logical viewport size for coordinate mapping |
 | `GET` | `/render/html` | `text/html` | Rendered DOM source (`page()->toHtml()`) |
@@ -480,8 +481,54 @@ All endpoints share the same `--auth-token` auth as the CDP endpoints: pass the 
 | `POST` | `/render/click?x=<px>&y=<px>&button=left\|right\|middle` | `text/plain` | Synthesize a mouse click at viewport coordinates (button defaults to `left`) |
 | `POST` | `/render/scroll?dy=<delta>&x=<px>&y=<px>` | `text/plain` | Synthesize a mouse wheel event; `dy` in angle-delta units (±120 per notch, positive scrolls up), `x`/`y` default to the viewport center |
 | `POST` | `/render/type?text=<text>` | `text/plain` | Type text into the focused element (URL-encoded query param, or raw request body) |
-| `POST` | `/render/key?key=<name>` | `text/plain` | Press a named key: `enter`, `tab`, `backspace`, `delete`, `escape`, `space`, `up`, `down`, `left`, `right`, `home`, `end`, `pageup`, `pagedown` |
-| `GET` | `/render/stream.mjpeg` | `multipart/x-mixed-replace` | MJPEG live stream (~10 fps) |
+| `POST` | `/render/key?key=<name>&mods=<list>` | `text/plain` | Press a named key: `enter`, `tab`, `backspace`, `delete`, `escape`, `space`, `up`, `down`, `left`, `right`, `home`, `end`, `pageup`, `pagedown`, `insert`, `f1`–`f12`, or a single character. `mods` is a comma-separated list of `ctrl`, `shift`, `alt`, `meta` — `key=a&mods=ctrl` is Select All |
+| `POST` | `/render/move?x=<px>&y=<px>&buttons=<list>&mods=<list>` | `text/plain` | Move the pointer. `buttons` names what is still held, which is what makes a move a drag rather than a hover |
+| `POST` | `/render/mousedown?x=<px>&y=<px>&button=<b>&mods=<list>` | `text/plain` | Press and hold |
+| `POST` | `/render/mouseup?x=<px>&y=<px>&button=<b>&mods=<list>` | `text/plain` | Release. A press and a release at one point is still a click |
+| `POST` | `/render/tab/new?url=<url>&name=<name>` | `application/json` | `{"id":"t3"}` |
+| `POST` | `/render/tab/close?tab=<id>` | `application/json` | Closes it; `409` for the last remaining tab |
+| `GET` | `/render/stream.mjpeg?tab=<id>` | `multipart/x-mixed-replace` | MJPEG live stream (~10 fps) of the named tab, or the active one |
+
+### Embedding the live view
+
+`/render` is a page you can put in an `<iframe>`. It streams the tab over MJPEG
+and forwards mouse and keyboard back, so the person looking at your app can use
+the browser — hover a menu, drag a selection, type into a form, press Ctrl+A —
+without leaving it.
+
+```html
+<iframe src="http://localhost:9222/render?embed=1&tab=t2&token=mysecret"
+        width="1280" height="720" style="border:0"></iframe>
+```
+
+- `embed=1` drops the tab bar and URL bar, leaving just the view. Omit it to get
+  the full viewer.
+- `tab=<id>` picks which tab this frame drives. Omit it to follow whichever tab
+  is active. Two frames on two tab ids drive two tabs at once — one can be the
+  agent's, one the user's.
+- `token=` is required when `--auth-token` is set. It stays in the frame's own
+  URL; the page is served verbatim and never has the server's token written
+  into it.
+- Click the view once before typing. Keyboard events only reach a focused
+  frame, and an iframe starts unfocused — the view says so until it has focus.
+
+**Who is allowed to frame it.** The view is not a picture of a browser, it is a
+handle on one. A page that can frame it can watch a logged-in session and act
+inside it. So the default is same-origin only, sent as
+`Content-Security-Policy: frame-ancestors 'self'`, and embedding elsewhere is
+opt-in:
+
+```bash
+./anoa --headless --port 9222 --embed-origin https://app.example.com
+```
+
+`--embed-origin` is repeatable. `--embed-origin '*'` removes the restriction
+altogether — the frame will load anywhere, which is worth doing only on a
+machine where that is already true of everything else.
+
+Note that the `/render/*` control endpoints have never carried an origin check
+of their own, and `--auth-token` is off by default. On a shared or untrusted
+machine, set a token.
 
 ### Usage example
 

--- a/README.md
+++ b/README.md
@@ -526,6 +526,16 @@ opt-in:
 altogether — the frame will load anywhere, which is worth doing only on a
 machine where that is already true of everything else.
 
+A named origin may also **read** the JSON endpoints — `Access-Control-Allow-Origin`
+echoes it back — so the host page can call `/json/list` and draw its own tab bar
+around the frame instead of using the one the viewer ships. Nothing is opened up
+that framing had not already opened: an origin trusted to drive the browser but
+not to list its tabs can show the view and not build anything around it. With no
+`--embed-origin` set, no CORS headers are sent at all.
+
+A worked example — host page, its own tab bar, new-tab button — is in
+[`examples/embed/`](examples/embed/).
+
 Note that the `/render/*` control endpoints have never carried an origin check
 of their own, and `--auth-token` is off by default. On a shared or untrusted
 machine, set a token.

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ All endpoints share the same `--auth-token` auth as the CDP endpoints: pass the 
 | `GET` | `/render/html` | `text/html` | Rendered DOM source (`page()->toHtml()`) |
 | `POST` | `/render/navigate?url=<url>` | `text/plain` | Load a URL into the embedded browser |
 | `POST` | `/render/click?x=<px>&y=<px>&button=left\|right\|middle` | `text/plain` | Synthesize a mouse click at viewport coordinates (button defaults to `left`) |
-| `POST` | `/render/scroll?dy=<delta>&x=<px>&y=<px>` | `text/plain` | Synthesize a mouse wheel event; `dy` in angle-delta units (±120 per notch, positive scrolls up), `x`/`y` default to the viewport center |
+| `POST` | `/render/scroll?dy=<delta>&x=<px>&y=<px>` | `text/plain` | Synthesize a mouse wheel event; `dy` in angle-delta units (±120 per notch, **negative scrolls down**), `x`/`y` default to the viewport center. Roughly 60 px of page per notch |
 | `POST` | `/render/type?text=<text>` | `text/plain` | Type text into the focused element (URL-encoded query param, or raw request body) |
 | `POST` | `/render/key?key=<name>&mods=<list>` | `text/plain` | Press a named key: `enter`, `tab`, `backspace`, `delete`, `escape`, `space`, `up`, `down`, `left`, `right`, `home`, `end`, `pageup`, `pagedown`, `insert`, `f1`–`f12`, or a single character. `mods` is a comma-separated list of `ctrl`, `shift`, `alt`, `meta` — `key=a&mods=ctrl` is Select All |
 | `POST` | `/render/move?x=<px>&y=<px>&buttons=<list>&mods=<list>` | `text/plain` | Move the pointer. `buttons` names what is still held, which is what makes a move a drag rather than a hover |

--- a/examples/embed/README.md
+++ b/examples/embed/README.md
@@ -1,0 +1,55 @@
+# Menyematkan live view anoa
+
+Halaman contoh yang menaruh browser anoa di dalam `<iframe>` dan mengemudikannya
+dari aplikasi lain.
+
+## Menjalankannya
+
+Dua proses: anoa, dan sebuah server statis untuk halaman contoh ini. Keduanya
+harus punya origin yang berbeda — itulah kasus yang sebenarnya ingin diuji.
+
+```bash
+# 1. anoa, dengan origin halaman contoh diizinkan mem-frame live view
+./anoa --headless --port 9222 --embed-origin http://127.0.0.1:8080
+
+# 2. sajikan halaman contoh (terminal lain)
+cd examples/embed && python3 -m http.server 8080 --bind 127.0.0.1
+```
+
+Lalu buka <http://127.0.0.1:8080/>.
+
+Tanpa `--embed-origin`, frame-nya ditolak dan browser menampilkan ikon dokumen
+rusak — bukan karena rusak, tapi karena defaultnya memang same-origin saja. Lihat
+"Siapa yang boleh menyematkannya" di bawah.
+
+## Yang ditunjukkan
+
+- **`?embed=1`** membuang bilah tab dan bilah URL bawaan viewer, menyisakan
+  tampilannya saja, supaya aplikasi Anda menggambar UI-nya sendiri.
+- **`?tab=<id>`** memilih tab mana yang dikemudikan frame itu. Dua frame dengan
+  dua id mengemudikan dua tab sekaligus.
+- **`/json/list`** memberi daftar tab beserta `anoaTabId`, `anoaTabName`,
+  `anoaActive`, judul dan URL-nya — cukup untuk menggambar bilah tab sendiri.
+- **`POST /render/tab/new`** membuka tab dan mengembalikan `{"id":"t3"}`.
+
+Interaksi tetikus dan papan ketik ditangani viewer di dalam frame; aplikasi
+tuan rumah tidak perlu meneruskan apa pun.
+
+## Beberapa hal yang mudah terlewat
+
+**Klik sekali sebelum mengetik.** Peristiwa papan ketik hanya sampai ke frame
+yang sedang fokus, dan sebuah iframe selalu mulai tanpa fokus. Viewer
+menampilkan pil kecil di pojok selama itu belum terjadi.
+
+**Token.** Kalau anoa dijalankan dengan `--auth-token`, isi konstanta `TOKEN` di
+`index.html`. Token itu tinggal di URL frame; halaman viewer disajikan apa
+adanya dan tidak pernah memuat token milik server di dalam badannya.
+
+**Siapa yang boleh menyematkannya.** Live view meneruskan ketikan, bukan sekadar
+menampilkan piksel — halaman yang bisa mem-frame-nya bisa menonton sesi yang
+sudah login dan bertindak di dalamnya. Karena itu defaultnya
+`Content-Security-Policy: frame-ancestors 'self'`, dan `--embed-origin` dipakai
+untuk melebarkannya (boleh diulang; `'*'` mencabutnya sama sekali).
+
+Perlu dicatat bahwa endpoint `/render/*` sendiri tidak punya pemeriksaan origin,
+dan `--auth-token` mati secara bawaan. Di mesin bersama, pasang token.

--- a/examples/embed/index.html
+++ b/examples/embed/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Contoh: menyematkan anoa</title>
+<style>
+  :root { --bg:#f5f6f8; --card:#fff; --ink:#1a1d23; --muted:#6b7280;
+          --line:#dfe3e9; --accent:#2f6fd0; }
+  * { box-sizing:border-box }
+  body { margin:0; background:var(--bg); color:var(--ink); padding:28px;
+         font:15px/1.6 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif }
+  h1 { margin:0 0 4px; font-size:20px }
+  .sub { margin:0 0 22px; color:var(--muted); font-size:14px }
+  .app { max-width:1120px; background:var(--card); border:1px solid var(--line);
+         border-radius:12px; overflow:hidden; box-shadow:0 1px 3px rgba(0,0,0,.06) }
+  .bar { display:flex; align-items:center; gap:8px; padding:10px 12px;
+         border-bottom:1px solid var(--line); flex-wrap:wrap }
+  button { font:inherit; font-size:13px; padding:6px 12px; border-radius:6px;
+           border:1px solid var(--line); background:#fff; color:var(--ink); cursor:pointer }
+  button:hover { border-color:var(--accent); color:var(--accent) }
+  button.on { background:var(--accent); border-color:var(--accent); color:#fff }
+  .spacer { flex:1 }
+  .hint { color:var(--muted); font-size:12.5px }
+  iframe { display:block; width:100%; height:620px; border:0; background:#000 }
+</style>
+</head>
+<body>
+
+<h1>Aplikasi saya</h1>
+<p class="sub">Browser anoa disematkan di bawah ini. Tombol tab digambar oleh aplikasi ini
+sendiri, dari daftar tab yang dibaca lewat <code>/json/list</code>.</p>
+
+<div class="app">
+  <div class="bar">
+    <span class="hint">Tab:</span>
+    <span id="tabs"></span>
+    <button id="new">+ Tab baru</button>
+    <span class="spacer"></span>
+    <span class="hint">Klik sekali di dalam tampilan sebelum mengetik.</span>
+  </div>
+  <iframe id="view" title="anoa live view"></iframe>
+</div>
+
+<script>
+// ── Ke mana anoa mendengarkan, dan tokennya kalau ada ───────────────────────
+const ANOA  = 'http://127.0.0.1:9222';
+const TOKEN = '';   // isi kalau anoa dijalankan dengan --auth-token
+
+let current = null; // tab yang sedang ditampilkan, mis. "t1"
+
+/** Tempelkan token ke query bila dipakai. */
+function q(params = {}) {
+  const p = new URLSearchParams(params);
+  if (TOKEN) p.set('token', TOKEN);
+  return p.toString();
+}
+
+/** Arahkan iframe ke satu tab. embed=1 membuang bilah tab bawaan viewer. */
+function show(tabId) {
+  current = tabId;
+  document.getElementById('view').src =
+    `${ANOA}/render?${q({ embed: '1', tab: tabId })}`;
+  paintTabs();
+}
+
+/** Gambar tombol tab dari daftar tab anoa sendiri. */
+async function refreshTabs() {
+  const resp = await fetch(`${ANOA}/json/list?${q()}`);
+  const list = (await resp.json()).filter(t => t.anoaTabId);
+  window.__tabs = list;
+  if (!current && list.length) show(list.find(t => t.anoaActive)?.anoaTabId ?? list[0].anoaTabId);
+  else paintTabs();
+}
+
+function paintTabs() {
+  const host = document.getElementById('tabs');
+  host.textContent = '';
+  for (const t of (window.__tabs ?? [])) {
+    const b = document.createElement('button');
+    b.textContent = t.anoaTabName || t.title || t.anoaTabId;
+    b.title = t.url || '';
+    if (t.anoaTabId === current) b.className = 'on';
+    b.onclick = () => show(t.anoaTabId);
+    host.appendChild(b);
+  }
+}
+
+document.getElementById('new').onclick = async () => {
+  const resp = await fetch(`${ANOA}/render/tab/new?${q({ url: 'https://example.com' })}`,
+                           { method: 'POST' });
+  const { id } = await resp.json();
+  await refreshTabs();
+  show(id);
+};
+
+refreshTabs();
+setInterval(refreshTabs, 3000);
+</script>
+
+</body>
+</html>

--- a/examples/embed/index.html
+++ b/examples/embed/index.html
@@ -37,6 +37,7 @@ sendiri, dari daftar tab yang dibaca lewat <code>/json/list</code>.</p>
     <span id="tabs"></span>
     <button id="new">+ Tab baru</button>
     <span class="spacer"></span>
+    <button id="inspect">Inspect</button>
     <span class="hint">Klik sekali di dalam tampilan sebelum mengetik.</span>
   </div>
   <iframe id="view" title="anoa live view"></iframe>
@@ -85,6 +86,21 @@ function paintTabs() {
     host.appendChild(b);
   }
 }
+
+// DevTools Chromium untuk tab yang sedang ditampilkan. Frontend-nya disajikan di
+// port debug anoa (port + 1) dan berbicara ke halaman lewat proxy CDP (port + 2)
+// — persis yang sudah disebut oleh webSocketDebuggerUrl di /json/list.
+document.getElementById('inspect').onclick = () => {
+  const t = (window.__tabs ?? []).find(x => x.anoaTabId === current);
+  if (!t) return;
+  const anoa = new URL(ANOA);
+  let ws = t.webSocketDebuggerUrl.replace(/^wss?:\/\//, '');
+  if (TOKEN) ws += `?token=${encodeURIComponent(TOKEN)}`;
+  const port = Number(anoa.port || 80) + 1;
+  // Jendela baru: DevTools di dalam iframe selebar 860px tidak bisa dipakai.
+  window.open(`${anoa.protocol}//${anoa.hostname}:${port}/devtools/inspector.html?ws=${ws}`,
+              '_blank', 'noopener');
+};
 
 document.getElementById('new').onclick = async () => {
   const resp = await fetch(`${ANOA}/render/tab/new?${q({ url: 'https://example.com' })}`,

--- a/resources/viewer/viewer.html
+++ b/resources/viewer/viewer.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Anoa Live View</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{width:100%;height:100%;background:#111;color:#ddd;overflow:hidden;
+  font:13px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+body{display:flex;flex-direction:column}
+#chrome{flex:0 0 auto;background:#1b1b1b;border-bottom:1px solid #000}
+body.embed #chrome{display:none}
+#tabs{display:flex;align-items:stretch;gap:1px;overflow-x:auto;scrollbar-width:thin}
+.tab{flex:0 1 190px;min-width:70px;display:flex;align-items:center;gap:6px;
+  padding:7px 10px;background:#232323;border:0;border-top:2px solid transparent;
+  color:#999;font:inherit;text-align:left;cursor:pointer;white-space:nowrap;overflow:hidden}
+.tab:hover{background:#2b2b2b}
+.tab.on{background:#111;color:#fff;border-top-color:#4a9eff}
+.tab .t{flex:1;overflow:hidden;text-overflow:ellipsis}
+.tab .x{flex:0 0 auto;width:16px;height:16px;border-radius:3px;line-height:15px;
+  text-align:center;color:#777}
+.tab .x:hover{background:#444;color:#fff}
+#newtab{flex:0 0 auto;padding:0 12px;background:#1b1b1b;border:0;color:#888;
+  font:inherit;font-size:16px;cursor:pointer}
+#newtab:hover{color:#fff}
+#bar{display:flex;align-items:center;gap:6px;padding:6px 8px}
+#bar button{background:#2a2a2a;border:0;color:#bbb;font:inherit;padding:5px 9px;
+  border-radius:4px;cursor:pointer}
+#bar button:hover{background:#383838;color:#fff}
+#url{flex:1;background:#111;border:1px solid #333;border-radius:4px;color:#ddd;
+  font:inherit;padding:6px 9px;min-width:0}
+#url:focus{outline:0;border-color:#4a9eff}
+#stage{flex:1;position:relative;background:#000;overflow:hidden;min-height:0}
+#stage:focus{outline:0}
+#stage.live{cursor:default}
+#frame{position:absolute;inset:0;width:100%;height:100%;object-fit:contain;
+  display:block;-webkit-user-select:none;user-select:none;-webkit-user-drag:none}
+#note{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
+  color:#666;font-size:12px;pointer-events:none;text-align:center}
+#hint{position:absolute;left:8px;bottom:8px;background:rgba(0,0,0,.72);color:#8a8a8a;
+  padding:3px 8px;border-radius:4px;font-size:11px;pointer-events:none;
+  opacity:0;transition:opacity .2s}
+#hint.show{opacity:1}
+</style>
+</head>
+<body>
+
+<div id="chrome">
+  <div style="display:flex">
+    <div id="tabs"></div>
+    <button id="newtab" title="New tab">+</button>
+  </div>
+  <div id="bar">
+    <button id="back" title="Back">←</button>
+    <button id="fwd" title="Forward">→</button>
+    <button id="reload" title="Reload">⟳</button>
+    <input id="url" placeholder="Enter a URL and press Return" spellcheck="false">
+  </div>
+</div>
+
+<div id="stage" tabindex="0">
+  <img id="frame" alt="">
+  <div id="note">connecting…</div>
+  <div id="hint">click to give this view the keyboard</div>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var Q = new URLSearchParams(location.search);
+  var TOKEN = Q.get("token") || "";
+  var EMBED = Q.get("embed") === "1";
+  // Which tab this viewer shows. Empty means "whichever is active", resolved
+  // server-side per request — so an unparameterised embed follows the browser.
+  var TAB = Q.get("tab") || "";
+
+  if (EMBED) document.body.classList.add("embed");
+
+  var stage = document.getElementById("stage");
+  var frame = document.getElementById("frame");
+  var note = document.getElementById("note");
+  var hint = document.getElementById("hint");
+  var tabsEl = document.getElementById("tabs");
+  var urlEl = document.getElementById("url");
+
+  // The tab's logical viewport, which is the coordinate space every input
+  // endpoint speaks. It is NOT the frame's pixel size: grab() returns device
+  // pixels, so on a HiDPI display the image is twice the width the browser
+  // thinks it is, and clicks mapped through the image land at double the
+  // intended point.
+  var vw = 0, vh = 0;
+
+  function qs(extra) {
+    var p = new URLSearchParams();
+    if (TAB) p.set("tab", TAB);
+    if (TOKEN) p.set("token", TOKEN);
+    for (var k in extra) if (extra[k] !== undefined && extra[k] !== "") p.set(k, extra[k]);
+    return p.toString();
+  }
+
+  function post(path, extra) {
+    return fetch(path + "?" + qs(extra), { method: "POST" }).catch(function () {});
+  }
+
+  // ── the frame ────────────────────────────────────────────────────────────
+  function connect() {
+    note.textContent = "connecting…";
+    note.style.display = "";
+    // A cache-buster is what makes a re-connect actually re-open the stream
+    // rather than resume the aborted one from cache.
+    frame.src = "/render/stream.mjpeg?" + qs({ _t: Date.now() });
+  }
+
+  frame.addEventListener("load", function () { note.style.display = "none"; });
+  frame.addEventListener("error", function () {
+    note.textContent = "stream lost — retrying";
+    note.style.display = "";
+    setTimeout(connect, 1500);
+  });
+
+  function refreshViewport() {
+    return fetch("/render/viewport?" + qs()).then(function (r) {
+      return r.ok ? r.json() : null;
+    }).then(function (j) {
+      if (j) { vw = j.width; vh = j.height; }
+    }).catch(function () {});
+  }
+
+  // ── coordinates ──────────────────────────────────────────────────────────
+  // object-fit: contain letterboxes the frame inside the stage, so the drawn
+  // rectangle is not the element's rectangle and the offset has to come out
+  // before the scale does.
+  function toViewport(ev) {
+    if (!vw || !vh) return null;
+    var box = frame.getBoundingClientRect();
+    if (!box.width || !box.height) return null;
+    var scale = Math.min(box.width / vw, box.height / vh);
+    var dw = vw * scale, dh = vh * scale;
+    var ox = box.left + (box.width - dw) / 2;
+    var oy = box.top + (box.height - dh) / 2;
+    var x = (ev.clientX - ox) / scale;
+    var y = (ev.clientY - oy) / scale;
+    if (x < 0 || y < 0 || x >= vw || y >= vh) return null;
+    return { x: Math.round(x), y: Math.round(y) };
+  }
+
+  var BUTTONS = ["left", "middle", "right"];
+  function buttonName(ev) { return BUTTONS[ev.button] || "left"; }
+
+  function heldNames(ev) {
+    var out = [];
+    if (ev.buttons & 1) out.push("left");
+    if (ev.buttons & 4) out.push("middle");
+    if (ev.buttons & 2) out.push("right");
+    return out.join(",");
+  }
+
+  function modNames(ev) {
+    var out = [];
+    if (ev.ctrlKey) out.push("ctrl");
+    if (ev.shiftKey) out.push("shift");
+    if (ev.altKey) out.push("alt");
+    if (ev.metaKey) out.push("meta");
+    return out.join(",");
+  }
+
+  // ── pointer ──────────────────────────────────────────────────────────────
+  stage.addEventListener("mousedown", function (ev) {
+    stage.focus();
+    var p = toViewport(ev);
+    if (!p) return;
+    ev.preventDefault();
+    post("/render/mousedown", { x: p.x, y: p.y, button: buttonName(ev), mods: modNames(ev) });
+  });
+
+  window.addEventListener("mouseup", function (ev) {
+    var p = toViewport(ev);
+    if (!p) return;
+    post("/render/mouseup", { x: p.x, y: p.y, button: buttonName(ev), mods: modNames(ev) });
+  });
+
+  // Moves are throttled to one in flight per frame budget. Unthrottled they
+  // outrun the server and queue up, and the pointer arrives late for the rest
+  // of the session.
+  var moveDue = null, moveTimer = 0;
+  function flushMove() {
+    moveTimer = 0;
+    if (!moveDue) return;
+    var m = moveDue; moveDue = null;
+    post("/render/move", m);
+  }
+  stage.addEventListener("mousemove", function (ev) {
+    var p = toViewport(ev);
+    if (!p) return;
+    moveDue = { x: p.x, y: p.y, buttons: heldNames(ev), mods: modNames(ev) };
+    if (!moveTimer) moveTimer = setTimeout(flushMove, 40);
+  });
+
+  stage.addEventListener("wheel", function (ev) {
+    var p = toViewport(ev);
+    if (!p) return;
+    ev.preventDefault();
+    // The endpoint takes Qt angle deltas: 120 units per notch, positive up,
+    // which is the opposite sign to the DOM's deltaY.
+    var dy = Math.round(-ev.deltaY * (ev.deltaMode === 1 ? 40 : 2));
+    if (!dy) dy = ev.deltaY > 0 ? -120 : 120;
+    post("/render/scroll", { x: p.x, y: p.y, dy: dy });
+  }, { passive: false });
+
+  // Right-click has to be swallowed here or the host page's menu opens on top
+  // of the page's own.
+  stage.addEventListener("contextmenu", function (ev) { ev.preventDefault(); });
+  stage.addEventListener("dragstart", function (ev) { ev.preventDefault(); });
+
+  // ── keyboard ─────────────────────────────────────────────────────────────
+  var NAMED = {
+    Enter: "enter", Tab: "tab", Backspace: "backspace", Delete: "delete",
+    Escape: "escape", ArrowUp: "up", ArrowDown: "down", ArrowLeft: "left",
+    ArrowRight: "right", Home: "home", End: "end", PageUp: "pageup",
+    PageDown: "pagedown", Insert: "insert"
+  };
+
+  stage.addEventListener("keydown", function (ev) {
+    var mods = modNames(ev);
+    var named = NAMED[ev.key];
+    if (!named && /^F([1-9]|1[0-2])$/.test(ev.key)) named = ev.key.toLowerCase();
+
+    if (named) {
+      ev.preventDefault();
+      post("/render/key", { key: named, mods: mods });
+      return;
+    }
+    if (ev.key.length !== 1) return; // Shift, Control, Dead keys and friends
+
+    if (ev.ctrlKey || ev.metaKey || ev.altKey) {
+      // A shortcut. Ctrl+C and the rest have to reach the page as a key with
+      // modifiers, not as typed text.
+      ev.preventDefault();
+      post("/render/key", { key: ev.key, mods: mods });
+      return;
+    }
+    ev.preventDefault();
+    post("/render/type", { text: ev.key });
+  });
+
+  stage.addEventListener("paste", function (ev) {
+    var text = (ev.clipboardData || window.clipboardData).getData("text");
+    if (!text) return;
+    ev.preventDefault();
+    post("/render/type", { text: text });
+  });
+
+  // Keyboard only reaches a focused element, and an iframe starts unfocused —
+  // so without this the view looks interactive and silently swallows typing.
+  stage.addEventListener("focus", function () { hint.classList.remove("show"); });
+  stage.addEventListener("blur", function () { hint.classList.add("show"); });
+  if (document.activeElement !== stage) hint.classList.add("show");
+
+  // ── tabs ─────────────────────────────────────────────────────────────────
+  function selectTab(id) {
+    TAB = id;
+    var u = new URL(location.href);
+    u.searchParams.set("tab", id);
+    history.replaceState(null, "", u);
+    refreshViewport().then(connect);
+  }
+
+  function renderTabs(list) {
+    tabsEl.textContent = "";
+    list.forEach(function (t) {
+      var id = t.anoaTabId;
+      var b = document.createElement("button");
+      b.className = "tab" + (id === TAB || (!TAB && t.anoaActive) ? " on" : "");
+      b.title = (t.anoaTabName ? t.anoaTabName + " · " : "") + (t.url || "");
+
+      var label = document.createElement("span");
+      label.className = "t";
+      label.textContent = t.anoaTabName || t.title || t.url || id;
+      b.appendChild(label);
+
+      if (list.length > 1) {
+        var x = document.createElement("span");
+        x.className = "x";
+        x.textContent = "×";
+        x.addEventListener("click", function (ev) {
+          ev.stopPropagation();
+          fetch("/render/tab/close?" + new URLSearchParams(
+            TOKEN ? { tab: id, token: TOKEN } : { tab: id }
+          ), { method: "POST" }).then(pollTabs);
+        });
+        b.appendChild(x);
+      }
+
+      b.addEventListener("click", function () { selectTab(id); });
+      tabsEl.appendChild(b);
+    });
+  }
+
+  function pollTabs() {
+    if (EMBED) return Promise.resolve();
+    return fetch("/json/list" + (TOKEN ? "?token=" + encodeURIComponent(TOKEN) : ""))
+      .then(function (r) { return r.json(); })
+      .then(function (list) {
+        list = list.filter(function (t) { return t.anoaTabId; });
+        if (!list.length) return;
+        renderTabs(list);
+        var shown = list.filter(function (t) {
+          return TAB ? t.anoaTabId === TAB : t.anoaActive;
+        })[0];
+        if (shown && document.activeElement !== urlEl) urlEl.value = shown.url || "";
+      })
+      .catch(function () {});
+  }
+
+  document.getElementById("newtab").addEventListener("click", function () {
+    fetch("/render/tab/new?" + (TOKEN ? "token=" + encodeURIComponent(TOKEN) : ""),
+          { method: "POST" })
+      .then(function (r) { return r.json(); })
+      .then(function (j) { if (j && j.id) selectTab(j.id); })
+      .then(pollTabs)
+      .catch(function () {});
+  });
+
+  // ── navigation ───────────────────────────────────────────────────────────
+  urlEl.addEventListener("keydown", function (ev) {
+    if (ev.key !== "Enter") return;
+    ev.stopPropagation();
+    var v = urlEl.value.trim();
+    if (!v) return;
+    post("/render/navigate", { url: v }).then(pollTabs);
+  });
+
+  document.getElementById("back").addEventListener("click", function () {
+    post("/render/back").then(pollTabs);
+  });
+  document.getElementById("fwd").addEventListener("click", function () {
+    post("/render/forward").then(pollTabs);
+  });
+  document.getElementById("reload").addEventListener("click", function () {
+    post("/render/reload").then(pollTabs);
+  });
+
+  // ── go ───────────────────────────────────────────────────────────────────
+  refreshViewport().then(connect);
+  pollTabs();
+  setInterval(pollTabs, 2000);
+  // The tab can be resized under us (--width/--height, or a window drag), and
+  // a stale viewport silently mis-maps every click from then on.
+  setInterval(refreshViewport, 5000);
+  window.addEventListener("resize", refreshViewport);
+})();
+</script>
+</body>
+</html>

--- a/resources/viewer/viewer.html
+++ b/resources/viewer/viewer.html
@@ -56,6 +56,7 @@ body.embed #chrome{display:none}
     <button id="fwd" title="Forward">→</button>
     <button id="reload" title="Reload">⟳</button>
     <input id="url" placeholder="Enter a URL and press Return" spellcheck="false">
+    <button id="inspect" title="Open DevTools for this tab">Inspect</button>
   </div>
 </div>
 
@@ -298,6 +299,10 @@ body.embed #chrome{display:none}
     });
   }
 
+  // The entry /json/list reports for the tab on screen, kept so Inspect knows
+  // which engine target to point DevTools at.
+  var shownEntry = null;
+
   function pollTabs() {
     if (EMBED) return Promise.resolve();
     return fetch("/json/list" + (TOKEN ? "?token=" + encodeURIComponent(TOKEN) : ""))
@@ -309,10 +314,28 @@ body.embed #chrome{display:none}
         var shown = list.filter(function (t) {
           return TAB ? t.anoaTabId === TAB : t.anoaActive;
         })[0];
+        shownEntry = shown || null;
         if (shown && document.activeElement !== urlEl) urlEl.value = shown.url || "";
       })
       .catch(function () {});
   }
+
+  // ── inspect ──────────────────────────────────────────────────────────────
+  // Chromium's own DevTools, already running: the frontend is served on the
+  // debugging port (ours + 1) and talks to the page over the CDP proxy (ours
+  // + 2), which is exactly what webSocketDebuggerUrl already names. Nothing new
+  // is stood up here — this was reachable all along and had no way in.
+  //
+  // A new window rather than this one: DevTools inside a 640-pixel frame is not
+  // usable, and the point is to inspect the page, not to replace the view of it.
+  document.getElementById("inspect").addEventListener("click", function () {
+    if (!shownEntry || !shownEntry.webSocketDebuggerUrl) return;
+    var ws = shownEntry.webSocketDebuggerUrl.replace(/^wss?:\/\//, "");
+    if (TOKEN) ws += "?token=" + encodeURIComponent(TOKEN);
+    var devtoolsPort = Number(location.port || 80) + 1;
+    window.open(location.protocol + "//" + location.hostname + ":" + devtoolsPort
+                + "/devtools/inspector.html?ws=" + ws, "_blank", "noopener");
+  });
 
   document.getElementById("newtab").addEventListener("click", function () {
     fetch("/render/tab/new?" + (TOKEN ? "token=" + encodeURIComponent(TOKEN) : ""),

--- a/resources/viewer/viewer.qrc
+++ b/resources/viewer/viewer.qrc
@@ -1,0 +1,11 @@
+<!DOCTYPE RCC>
+<!--
+  The live-view page, compiled into the binary for the same reason the icon is:
+  anoa is shipped as a relocatable bundle and an AppImage, and a page looked up
+  by path is a page that is sometimes missing.
+-->
+<RCC version="1.0">
+  <qresource prefix="/">
+    <file alias="viewer.html">viewer.html</file>
+  </qresource>
+</RCC>

--- a/src/agent/agent_help.cpp
+++ b/src/agent/agent_help.cpp
@@ -29,6 +29,8 @@ const Group kGroups[] = {
     --profile-dir <dir>             where profiles live
     --extension <path>              load an unpacked extension (repeatable)
     --auth-token <secret>           require this bearer token on CDP
+    --embed-origin <origin>         let this origin iframe the live view at
+                                    /render (repeatable; default same-origin)
     --config <file>                 JSON or INI file of the above
     -v, --version                   print the version and exit
 

--- a/src/browser/anoa_browser.cpp
+++ b/src/browser/anoa_browser.cpp
@@ -951,7 +951,8 @@ static QWidget *inputTarget(QWebEngineView *view)
     return proxy ? proxy : static_cast<QWidget *>(view);
 }
 
-void AnoaBrowser::sendClick(const QPoint &pos, Qt::MouseButton button, const QString &tabId)
+void AnoaBrowser::sendClick(const QPoint &pos, Qt::MouseButton button, const QString &tabId,
+                            Qt::KeyboardModifiers mods)
 {
     QWidget *target = inputTarget(viewForOrActive(tabId));
     if (!target)
@@ -964,17 +965,60 @@ void AnoaBrowser::sendClick(const QPoint &pos, Qt::MouseButton button, const QSt
     // Leading move puts the pointer at the click position so hover/hit-testing
     // state matches a real interaction before the press arrives.
     auto *move = new QMouseEvent(QEvent::MouseMove, posF, posF, globalF,
-                                 Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+                                 Qt::NoButton, Qt::NoButton, mods);
     move->setTimestamp(stamp);
     auto *press = new QMouseEvent(QEvent::MouseButtonPress, posF, posF, globalF,
-                                  button, button, Qt::NoModifier);
+                                  button, button, mods);
     press->setTimestamp(stamp + 1);
     auto *release = new QMouseEvent(QEvent::MouseButtonRelease, posF, posF, globalF,
-                                    button, Qt::NoButton, Qt::NoModifier);
+                                    button, Qt::NoButton, mods);
     release->setTimestamp(stamp + 50);
     QCoreApplication::postEvent(target, move);
     QCoreApplication::postEvent(target, press);
     QCoreApplication::postEvent(target, release);
+}
+
+// The three below share everything except the event type and which buttons are
+// reported held, so they post through one helper rather than three copies that
+// would drift.
+static void postMouse(QWidget *target, QEvent::Type type, const QPoint &pos,
+                      Qt::MouseButton button, Qt::MouseButtons held,
+                      Qt::KeyboardModifiers mods)
+{
+    if (!target)
+        return;
+    const QPointF posF(pos);
+    const QPointF globalF(target->mapToGlobal(pos));
+    auto *ev = new QMouseEvent(type, posF, posF, globalF, button, held, mods);
+    // Same reason as sendClick: a zero timestamp reads as "same instant as the
+    // last one", and a stream of those is a multi-click, not a drag.
+    ev->setTimestamp(static_cast<quint64>(QDateTime::currentMSecsSinceEpoch()));
+    QCoreApplication::postEvent(target, ev);
+}
+
+void AnoaBrowser::sendMouseMove(const QPoint &pos, Qt::MouseButtons heldButtons,
+                                Qt::KeyboardModifiers mods, const QString &tabId)
+{
+    // Qt reports no *triggering* button on a move — the buttons still down go
+    // in the third argument. Passing the held set as the trigger instead makes
+    // Chromium read every move as a fresh press.
+    postMouse(inputTarget(viewForOrActive(tabId)), QEvent::MouseMove, pos,
+              Qt::NoButton, heldButtons, mods);
+}
+
+void AnoaBrowser::sendMouseDown(const QPoint &pos, Qt::MouseButton button,
+                                Qt::KeyboardModifiers mods, const QString &tabId)
+{
+    postMouse(inputTarget(viewForOrActive(tabId)), QEvent::MouseButtonPress, pos,
+              button, button, mods);
+}
+
+void AnoaBrowser::sendMouseUp(const QPoint &pos, Qt::MouseButton button,
+                              Qt::KeyboardModifiers mods, const QString &tabId)
+{
+    // The button is released, so it is the trigger but no longer held.
+    postMouse(inputTarget(viewForOrActive(tabId)), QEvent::MouseButtonRelease, pos,
+              button, Qt::NoButton, mods);
 }
 
 void AnoaBrowser::sendScroll(const QPoint &pos, int angleDeltaY, const QString &tabId)
@@ -1007,7 +1051,8 @@ void AnoaBrowser::sendText(const QString &text, const QString &tabId)
     }
 }
 
-bool AnoaBrowser::sendKey(const QString &keyName, const QString &tabId)
+bool AnoaBrowser::sendKey(const QString &keyName, const QString &tabId,
+                          Qt::KeyboardModifiers mods)
 {
     struct NamedKey {
         const char *name;
@@ -1029,22 +1074,56 @@ bool AnoaBrowser::sendKey(const QString &keyName, const QString &tabId)
         {"end", Qt::Key_End, ""},
         {"pageup", Qt::Key_PageUp, ""},
         {"pagedown", Qt::Key_PageDown, ""},
+        {"insert", Qt::Key_Insert, ""},
+    };
+
+    QWidget *target = inputTarget(viewForOrActive(tabId));
+    if (!target)
+        return false;
+
+    // A shortcut carries no text. Chromium turns text into an insertion, so
+    // Ctrl+A with text "a" both selects all and types an "a".
+    const bool isShortcut = mods & (Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier);
+
+    auto post = [&](Qt::Key key, const QString &text) {
+        const QString payload = isShortcut ? QString() : text;
+        QCoreApplication::postEvent(target,
+            new QKeyEvent(QEvent::KeyPress, key, mods, payload));
+        QCoreApplication::postEvent(target,
+            new QKeyEvent(QEvent::KeyRelease, key, mods, payload));
     };
 
     const QString wanted = keyName.toLower();
     for (const NamedKey &k : keys) {
         if (wanted == QLatin1String(k.name)) {
-            QWidget *target = inputTarget(viewForOrActive(tabId));
-            if (!target)
-                return false;
-            QCoreApplication::postEvent(target,
-                new QKeyEvent(QEvent::KeyPress, k.key, Qt::NoModifier,
-                              QString::fromLatin1(k.text)));
-            QCoreApplication::postEvent(target,
-                new QKeyEvent(QEvent::KeyRelease, k.key, Qt::NoModifier,
-                              QString::fromLatin1(k.text)));
+            post(k.key, QString::fromLatin1(k.text));
             return true;
         }
     }
+
+    // f1..f12. Spelled out rather than tabulated because the enum is contiguous
+    // and twelve more table rows would say less than this does.
+    if (wanted.size() >= 2 && wanted.at(0) == QLatin1Char('f')) {
+        bool ok = false;
+        const int n = QStringView{wanted}.mid(1).toInt(&ok);
+        if (ok && n >= 1 && n <= 12) {
+            post(static_cast<Qt::Key>(Qt::Key_F1 + n - 1), QString());
+            return true;
+        }
+    }
+
+    // A single printable character, which is what a shortcut needs: "a" alone
+    // is better served by sendText, but Ctrl+"a" has no other way in.
+    if (keyName.size() == 1) {
+        const QChar ch = keyName.at(0);
+        if (ch.isPrint()) {
+            // Qt's key codes for letters and digits are their uppercase ASCII
+            // values; anything else printable maps to its own code point.
+            const QChar upper = ch.toUpper();
+            post(static_cast<Qt::Key>(upper.unicode()), keyName);
+            return true;
+        }
+    }
+
     return false;
 }

--- a/src/browser/anoa_browser.cpp
+++ b/src/browser/anoa_browser.cpp
@@ -1028,12 +1028,38 @@ void AnoaBrowser::sendScroll(const QPoint &pos, int angleDeltaY, const QString &
         return;
     const QPointF posF(pos);
     const QPointF globalF(target->mapToGlobal(pos));
+    const auto stamp = static_cast<quint64>(QDateTime::currentMSecsSinceEpoch());
+
+    auto post = [&](const QPoint &angle, const QPoint &pixels, Qt::ScrollPhase phase,
+                    quint64 at) {
+        auto *wheel = new QWheelEvent(posF, globalF, pixels, angle,
+                                      Qt::NoButton, Qt::NoModifier, phase, false);
+        wheel->setTimestamp(at);
+        QCoreApplication::postEvent(target, wheel);
+    };
+
+#ifdef Q_OS_MACOS
+    // macOS has no phaseless wheel. Qt delivers real scroll input there as a
+    // gesture — begin, update, end — and QtWebEngine maps Qt::NoScrollPhase to
+    // a Blink phase Chromium drops on the floor. The event was posted, accepted
+    // and discarded: /render/scroll answered "scrolled", the page never saw a
+    // wheel event at all, and nothing moved. Verified against Linux/aarch64,
+    // where the same phaseless event scrolls correctly.
+    //
+    // pixelDelta is what a phased event is steered by, and it has to be filled
+    // in or the gesture is a no-op with a different shape. angleDelta/2 is the
+    // ratio measured on Linux — 600 angle units moved the page 300 px — so the
+    // two platforms scroll the same distance for the same request.
+    const QPoint angle(0, angleDeltaY);
+    const QPoint pixels(0, angleDeltaY / 2);
+    post(QPoint(), QPoint(), Qt::ScrollBegin, stamp);
+    post(angle, pixels, Qt::ScrollUpdate, stamp + 1);
+    post(QPoint(), QPoint(), Qt::ScrollEnd, stamp + 2);
+#else
     // Null pixelDelta = classic notched wheel; angleDelta is in 1/8 degree,
     // one wheel notch = 120.
-    auto *wheel = new QWheelEvent(posF, globalF, QPoint(), QPoint(0, angleDeltaY),
-                                  Qt::NoButton, Qt::NoModifier, Qt::NoScrollPhase, false);
-    wheel->setTimestamp(static_cast<quint64>(QDateTime::currentMSecsSinceEpoch()));
-    QCoreApplication::postEvent(target, wheel);
+    post(QPoint(0, angleDeltaY), QPoint(), Qt::NoScrollPhase, stamp);
+#endif
 }
 
 void AnoaBrowser::sendText(const QString &text, const QString &tabId)

--- a/src/browser/anoa_browser.h
+++ b/src/browser/anoa_browser.h
@@ -104,10 +104,29 @@ public:
 
     // An empty tabId means the active tab, which is what every caller that
     // has never heard of tabs passes.
-    void sendClick(const QPoint &pos, Qt::MouseButton button, const QString &tabId = QString());
+    // Modifiers are appended rather than inserted so every existing call site
+    // keeps compiling and keeps meaning what it meant.
+    void sendClick(const QPoint &pos, Qt::MouseButton button, const QString &tabId = QString(),
+                   Qt::KeyboardModifiers mods = Qt::NoModifier);
     void sendScroll(const QPoint &pos, int angleDeltaY, const QString &tabId = QString());
     void sendText(const QString &text, const QString &tabId = QString());
-    bool sendKey(const QString &keyName, const QString &tabId = QString());
+    bool sendKey(const QString &keyName, const QString &tabId = QString(),
+                 Qt::KeyboardModifiers mods = Qt::NoModifier);
+
+    // A click is a press and a release at one point, which is enough to drive a
+    // page from a script and not enough to drive one with a pointer. Hover
+    // state is what opens a menu; a press held across moves is what selecting
+    // text and dragging an element are. The live view needs all three as
+    // separate events, so they are separate here.
+    void sendMouseMove(const QPoint &pos, Qt::MouseButtons heldButtons = Qt::NoButton,
+                       Qt::KeyboardModifiers mods = Qt::NoModifier,
+                       const QString &tabId = QString());
+    void sendMouseDown(const QPoint &pos, Qt::MouseButton button,
+                       Qt::KeyboardModifiers mods = Qt::NoModifier,
+                       const QString &tabId = QString());
+    void sendMouseUp(const QPoint &pos, Qt::MouseButton button,
+                     Qt::KeyboardModifiers mods = Qt::NoModifier,
+                     const QString &tabId = QString());
 
 signals:
     void downloadFinished(const QString &path, bool ok);

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -169,6 +169,9 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
     QCommandLineOption extensionOpt("extension", "Path to an unpacked extension directory (repeatable)", "path");
     QCommandLineOption authTokenOpt("auth-token", "Bearer token required for CDP WebSocket connections", "token");
     QCommandLineOption configOpt("config", "Path to JSON or INI config file", "file");
+    QCommandLineOption embedOriginOpt("embed-origin",
+        "Origin allowed to iframe the live view, e.g. https://app.example.com "
+        "(repeatable; \"*\" allows any, default is same-origin only)", "origin");
     QCommandLineOption widthOpt(QStringList{"width"}, "Browser viewport/window width in pixels (default 1280)", "width");
     QCommandLineOption heightOpt(QStringList{"height"}, "Browser viewport/window height in pixels (default 720)", "height");
 
@@ -191,6 +194,7 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
     parser.addOption(profileNameOpt);
     parser.addOption(extensionOpt);
     parser.addOption(authTokenOpt);
+    parser.addOption(embedOriginOpt);
     parser.addOption(configOpt);
     parser.addOption(widthOpt);
     parser.addOption(heightOpt);
@@ -225,6 +229,8 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
         cfg.profileName = parser.value(profileNameOpt);
     if (parser.isSet(authTokenOpt))
         cfg.authToken = parser.value(authTokenOpt);
+    if (parser.isSet(embedOriginOpt))
+        cfg.embedOrigins = parser.values(embedOriginOpt);
 
     if (parser.isSet(widthOpt)) {
         bool ok = false;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -18,6 +18,10 @@ struct Config {
     QString profileName;
     QStringList extensionPaths;
     QString authToken;
+    // Origins allowed to put the live view (/render) in an iframe. Empty means
+    // 'self' only, because the view forwards input as well as showing pixels —
+    // a page that can frame it can drive the browser. "*" opts out entirely.
+    QStringList embedOrigins;
     int width = 1280;
     int height = 720;
 

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -21,6 +21,8 @@
 #include <QNetworkRequest>
 #include <QPixmap>
 #include <QTcpSocket>
+#include <QFile>
+#include <QPointer>
 #include <QTimer>
 #include <QUrl>
 #include <QUrlQuery>
@@ -148,6 +150,68 @@ QByteArray HttpServer::rebuildTargetList(const QByteArray &rewritten,
     }
 
     return QJsonDocument(out).toJson(QJsonDocument::Compact);
+}
+
+// `?mods=ctrl,shift` — comma-separated, order-free, unknown names ignored so a
+// client that learns a new modifier before this server does degrades to sending
+// the event unmodified rather than losing it to a 400.
+static Qt::KeyboardModifiers parseModifiers(const QString &spec)
+{
+    Qt::KeyboardModifiers mods = Qt::NoModifier;
+    const QStringList parts = spec.split(QLatin1Char(','), Qt::SkipEmptyParts);
+    for (const QString &raw : parts) {
+        const QString name = raw.trimmed().toLower();
+        if (name == QLatin1String("ctrl") || name == QLatin1String("control"))
+            mods |= Qt::ControlModifier;
+        else if (name == QLatin1String("shift"))
+            mods |= Qt::ShiftModifier;
+        else if (name == QLatin1String("alt"))
+            mods |= Qt::AltModifier;
+        else if (name == QLatin1String("meta") || name == QLatin1String("cmd"))
+            mods |= Qt::MetaModifier;
+    }
+    return mods;
+}
+
+// Shared by click and the three pointer endpoints, so "right" means the same
+// button everywhere. Returns false for a name none of them accept.
+static bool parseButton(const QString &spec, Qt::MouseButton *out)
+{
+    const QString name = spec.toLower();
+    if (name.isEmpty() || name == QLatin1String("left"))
+        *out = Qt::LeftButton;
+    else if (name == QLatin1String("right"))
+        *out = Qt::RightButton;
+    else if (name == QLatin1String("middle"))
+        *out = Qt::MiddleButton;
+    else
+        return false;
+    return true;
+}
+
+QByteArray HttpServer::frameAncestorsHeader() const
+{
+    // The live view is not a picture of a browser, it is a handle on one: it
+    // streams the screen and it forwards clicks and keystrokes. A page that can
+    // frame it can read a logged-in session and act inside it, invisibly, from
+    // any site the user happens to be visiting. The control endpoints have
+    // always been reachable cross-origin, but blind — framing is what turns
+    // that into a session someone can see and steer.
+    //
+    // So the default is 'self': the viewer frames itself and nothing else does,
+    // and embedding somewhere real is one flag away. A refused frame says so in
+    // the console, which is a better way to find out than never finding out.
+    if (m_embedOrigins.contains(QStringLiteral("*")))
+        return QByteArray();
+
+    QByteArray value = "'self'";
+    for (const QString &origin : m_embedOrigins) {
+        const QString trimmed = origin.trimmed();
+        if (trimmed.isEmpty())
+            continue;
+        value += " " + trimmed.toUtf8();
+    }
+    return "Content-Security-Policy: frame-ancestors " + value + "\r\n";
 }
 
 QWebEngineView *HttpServer::resolveRenderTab(const QUrlQuery &query, QString *badId) const
@@ -443,47 +507,74 @@ void HttpServer::handleNewConnection()
         }
         sendResponse(socket, 200, "OK", "ok", "text/plain");
     } else if (method == QLatin1String("GET") && path == QLatin1String("/render")) {
-        QString screenshotUrl = QStringLiteral("/render/screenshot.png");
-        if (!m_authToken.isEmpty()) {
-            QUrlQuery screenshotQuery;
-            screenshotQuery.addQueryItem(QStringLiteral("token"), m_authToken);
-            screenshotUrl += QStringLiteral("?") + screenshotQuery.toString(QUrl::FullyEncoded);
+        // The page used to be a two-line poller built here as a format string.
+        // It is now a real viewer — tabs, a URL bar and every input event —
+        // which is more markup than belongs in a C++ literal, so it lives in
+        // the resource bundle and is served verbatim. The token and the tab
+        // travel in the query string the client already has, so nothing has to
+        // be substituted on the way out.
+        QFile page(QStringLiteral(":/viewer.html"));
+        if (!page.open(QIODevice::ReadOnly)) {
+            sendResponse(socket, 500, "Internal Server Error", "viewer missing", "text/plain");
+            return;
         }
-
-        static const char htmlTmpl[] = R"(<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<title>Anoa Live View</title>
-<style>
-*{margin:0;padding:0;box-sizing:border-box}
-html,body{width:100%;height:100%;background:#000;overflow:hidden}
-#frame{display:block;width:100%;height:100%;object-fit:contain}
-</style>
-</head>
-<body>
-<img id="frame">
-<script>
-var src="%1";
-var img=document.getElementById("frame");
-function refresh(){img.src=src+(src.indexOf("?")>=0?"&":"?")+"_t="+Date.now();}
-refresh();
-setInterval(refresh,500);
-</script>
-</body>
-</html>)";
-
-        QByteArray htmlBytes = QString::fromUtf8(htmlTmpl).arg(screenshotUrl).toUtf8();
+        const QByteArray htmlBytes = page.readAll();
         QByteArray response =
             "HTTP/1.1 200 OK\r\n"
             "Content-Type: text/html; charset=utf-8\r\n"
-            "Cache-Control: no-cache\r\n"
+            "Cache-Control: no-cache\r\n";
+        response += frameAncestorsHeader();
+        response +=
             "Content-Length: " + QByteArray::number(htmlBytes.size()) + "\r\n"
             "Connection: close\r\n"
             "\r\n";
         response += htmlBytes;
         socket->write(response);
         closeWhenSent(socket);
+    } else if (method == QLatin1String("GET") && path == QLatin1String("/render/viewport")) {
+        // The logical size of the tab, which is the coordinate space every
+        // input endpoint speaks. A client cannot infer it from the frame:
+        // grab() returns device pixels, so on a HiDPI display the image is
+        // twice as wide as the coordinates that drive it.
+        if (!renderView) {
+            sendResponse(socket, 503, "Service Unavailable", R"({"error":"no browser"})");
+            return;
+        }
+        QJsonObject obj;
+        obj[QStringLiteral("width")] = renderView->width();
+        obj[QStringLiteral("height")] = renderView->height();
+        obj[QStringLiteral("dpr")] = renderView->devicePixelRatioF();
+        sendResponse(socket, 200, "OK", QJsonDocument(obj).toJson(QJsonDocument::Compact));
+    } else if (method == QLatin1String("POST") && path == QLatin1String("/render/tab/new")) {
+        if (!m_browser) {
+            sendResponse(socket, 503, "Service Unavailable", R"({"error":"no browser"})");
+            return;
+        }
+        const QString target = query.queryItemValue(QStringLiteral("url"), QUrl::FullyDecoded);
+        const QString wanted = query.queryItemValue(QStringLiteral("name"));
+        const QString id = m_browser->newTab(target.isEmpty() ? QUrl() : QUrl(target),
+                                             QString(), false, wanted);
+        if (id.isEmpty()) {
+            sendResponse(socket, 400, "Bad Request", R"({"error":"could not open tab"})");
+            return;
+        }
+        QJsonObject obj;
+        obj[QStringLiteral("id")] = id;
+        sendResponse(socket, 200, "OK", QJsonDocument(obj).toJson(QJsonDocument::Compact));
+    } else if (method == QLatin1String("POST") && path == QLatin1String("/render/tab/close")) {
+        // The tab was already resolved and 404'd above if it does not exist, so
+        // reaching here with an empty id means no ?tab= was given at all.
+        if (!m_browser || renderTabId.isEmpty()) {
+            sendResponse(socket, 400, "Bad Request", R"({"error":"tab required"})");
+            return;
+        }
+        // Refuses the last tab, by the same rule the CLI follows: one process
+        // still means at least one page.
+        if (!m_browser->closeTab(renderTabId)) {
+            sendResponse(socket, 409, "Conflict", R"({"error":"cannot close the last tab"})");
+            return;
+        }
+        sendResponse(socket, 200, "OK", R"({"closed":true})");
     } else if (method == QLatin1String("GET")
                && path == QLatin1String("/render/screenshot.ppm")) {
         // Binary PPM (P6) frame, optionally scaled server-side via ?w=&h=.
@@ -538,13 +629,8 @@ setInterval(refresh,500);
             return;
         }
 
-        QString buttonStr = query.queryItemValue(QStringLiteral("button")).toLower();
         Qt::MouseButton button = Qt::LeftButton;
-        if (buttonStr == QLatin1String("right"))
-            button = Qt::RightButton;
-        else if (buttonStr == QLatin1String("middle"))
-            button = Qt::MiddleButton;
-        else if (!buttonStr.isEmpty() && buttonStr != QLatin1String("left")) {
+        if (!parseButton(query.queryItemValue(QStringLiteral("button")), &button)) {
             sendResponse(socket, 400, "Bad Request", "invalid button", "text/plain");
             return;
         }
@@ -554,8 +640,60 @@ setInterval(refresh,500);
             return;
         }
 
-        m_browser->sendClick(QPoint(x, y), button, renderTabId);
+        m_browser->sendClick(QPoint(x, y), button, renderTabId,
+                             parseModifiers(query.queryItemValue(QStringLiteral("mods"))));
         sendResponse(socket, 200, "OK", "clicked", "text/plain");
+    } else if (method == QLatin1String("POST")
+               && (path == QLatin1String("/render/move")
+                   || path == QLatin1String("/render/mousedown")
+                   || path == QLatin1String("/render/mouseup"))) {
+        // Press, move and release as separate events. A click endpoint can
+        // drive a page from a script; it cannot hover a menu open or drag a
+        // selection across one, because both of those are a state that spans
+        // more than one event.
+        bool okX = false, okY = false;
+        const int x = query.queryItemValue(QStringLiteral("x")).toInt(&okX);
+        const int y = query.queryItemValue(QStringLiteral("y")).toInt(&okY);
+        if (!okX || !okY || x < 0 || y < 0) {
+            sendResponse(socket, 400, "Bad Request", "invalid coordinates", "text/plain");
+            return;
+        }
+
+        Qt::MouseButton button = Qt::LeftButton;
+        if (!parseButton(query.queryItemValue(QStringLiteral("button")), &button)) {
+            sendResponse(socket, 400, "Bad Request", "invalid button", "text/plain");
+            return;
+        }
+
+        if (!m_browser) {
+            sendResponse(socket, 503, "Service Unavailable", "no browser", "text/plain");
+            return;
+        }
+
+        const Qt::KeyboardModifiers mods =
+            parseModifiers(query.queryItemValue(QStringLiteral("mods")));
+        const QPoint pos(x, y);
+
+        if (path == QLatin1String("/render/mousedown")) {
+            m_browser->sendMouseDown(pos, button, mods, renderTabId);
+            sendResponse(socket, 200, "OK", "pressed", "text/plain");
+        } else if (path == QLatin1String("/render/mouseup")) {
+            m_browser->sendMouseUp(pos, button, mods, renderTabId);
+            sendResponse(socket, 200, "OK", "released", "text/plain");
+        } else {
+            // `?buttons=` is what is still held during the move, which is what
+            // separates a drag from a hover. Absent means nothing is down.
+            Qt::MouseButtons held = Qt::NoButton;
+            const QString heldSpec = query.queryItemValue(QStringLiteral("buttons"));
+            const QStringList heldNames = heldSpec.split(QLatin1Char(','), Qt::SkipEmptyParts);
+            for (const QString &name : heldNames) {
+                Qt::MouseButton b = Qt::LeftButton;
+                if (parseButton(name.trimmed(), &b))
+                    held |= b;
+            }
+            m_browser->sendMouseMove(pos, held, mods, renderTabId);
+            sendResponse(socket, 200, "OK", "moved", "text/plain");
+        }
     } else if (method == QLatin1String("POST") && path == QLatin1String("/render/scroll")) {
         bool okDy = false;
         int dy = query.queryItemValue(QStringLiteral("dy")).toInt(&okDy);
@@ -618,7 +756,8 @@ setInterval(refresh,500);
             return;
         }
 
-        if (!m_browser->sendKey(keyName, renderTabId)) {
+        if (!m_browser->sendKey(keyName, renderTabId,
+                                parseModifiers(query.queryItemValue(QStringLiteral("mods"))))) {
             sendResponse(socket, 400, "Bad Request", "unknown key", "text/plain");
             return;
         }
@@ -640,15 +779,20 @@ setInterval(refresh,500);
         QTimer *frameTimer = new QTimer(socket);
         frameTimer->setInterval(100);
 
-        AnoaBrowser *browser = m_browser;
-        connect(frameTimer, &QTimer::timeout, socket, [browser, socket]() {
+        // The tab resolved for this request, not the container. Grabbing the
+        // container gives whatever is raised, so `?tab=` was accepted and then
+        // ignored: asking for a background tab streamed the active one, with
+        // nothing anywhere to say so. Held as a QPointer because the stream
+        // outlives the request and a tab can be closed while it runs.
+        QPointer<QWebEngineView> streamView(renderView);
+        connect(frameTimer, &QTimer::timeout, socket, [streamView, socket]() {
             // Skip this frame if the write buffer is backed up beyond 512 KB.
             if (socket->bytesToWrite() > 512 * 1024)
                 return;
-            if (!browser)
+            if (!streamView)
                 return;
 
-            QPixmap pixmap = browser->grab();
+            QPixmap pixmap = streamView->grab();
             if (pixmap.isNull())
                 return;
 

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -75,13 +75,29 @@ static void closeWhenSent(QTcpSocket *socket)
     socket->disconnectFromHost();
 }
 
+// The CORS lines for this connection, decided once when the request is parsed
+// and carried on the socket itself.
+//
+// A dynamic property rather than an argument threaded through every call site,
+// and rather than a member: several handlers answer asynchronously, long after
+// the request that set it has returned, so the value has to belong to the
+// connection and not to the server.
+static const char *kCorsProperty = "anoaCors";
+
+static QByteArray corsFor(QTcpSocket *socket)
+{
+    return socket ? socket->property(kCorsProperty).toByteArray() : QByteArray();
+}
+
 static void sendResponse(QTcpSocket *socket, int statusCode, const QByteArray &statusText,
                          const QByteArray &body,
                          const QByteArray &contentType = "application/json")
 {
     QByteArray response =
         "HTTP/1.1 " + QByteArray::number(statusCode) + " " + statusText + "\r\n"
-        "Content-Type: " + contentType + "\r\n"
+        "Content-Type: " + contentType + "\r\n";
+    response += corsFor(socket);
+    response +=
         "Content-Length: " + QByteArray::number(body.size()) + "\r\n"
         "Connection: close\r\n"
         "\r\n" + body;
@@ -189,6 +205,32 @@ static bool parseButton(const QString &spec, Qt::MouseButton *out)
     return true;
 }
 
+QByteArray HttpServer::corsHeadersFor(const QString &origin) const
+{
+    // Same list as framing, and for the same reason: --embed-origin says an
+    // origin is trusted to embed the view and drive the browser through it. An
+    // origin trusted with that but not allowed to read /json/list can show the
+    // view and cannot draw a tab bar around it, which is most of what embedding
+    // is for. Nothing is opened up that framing had not already opened.
+    //
+    // Silence unless an origin was named, so the default configuration answers
+    // exactly as it did before.
+    if (origin.isEmpty() || m_embedOrigins.isEmpty())
+        return QByteArray();
+
+    const bool any = m_embedOrigins.contains(QStringLiteral("*"));
+    if (!any && !m_embedOrigins.contains(origin))
+        return QByteArray();
+
+    // The caller's own origin is echoed rather than "*", so a future credentialed
+    // request does not have to be rewritten. Vary: Origin keeps a cache from
+    // handing one origin's answer to another.
+    return "Access-Control-Allow-Origin: " + origin.toUtf8() + "\r\n"
+           "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
+           "Access-Control-Allow-Headers: Authorization, Content-Type\r\n"
+           "Vary: Origin\r\n";
+}
+
 QByteArray HttpServer::frameAncestorsHeader() const
 {
     // The live view is not a picture of a browser, it is a handle on one: it
@@ -278,6 +320,21 @@ void HttpServer::handleNewConnection()
     QUrlQuery query(url.query());
     QString hostHeader = headers.value(QStringLiteral("host"),
                                        QStringLiteral("127.0.0.1:%1").arg(m_port));
+
+    // Decided before anything can answer, and carried on the connection, so the
+    // handlers that reply asynchronously still send it.
+    socket->setProperty(kCorsProperty,
+                        corsHeadersFor(headers.value(QStringLiteral("origin"))));
+
+    // A preflight is asked before the request it is about, so it cannot be
+    // behind the auth check — the browser sends no credentials with it, and
+    // answering 401 here fails the actual request with a CORS error that names
+    // no cause. An origin we do not allow gets no CORS lines and the browser
+    // stops it on its own, which is the correct outcome and a clear one.
+    if (method == QLatin1String("OPTIONS")) {
+        sendResponse(socket, 204, "No Content", QByteArray(), "text/plain");
+        return;
+    }
 
     if (!m_authToken.isEmpty()) {
         QString authHeader = headers.value(QStringLiteral("authorization"));

--- a/src/http/http_server.h
+++ b/src/http/http_server.h
@@ -41,6 +41,9 @@ private:
     // The Content-Security-Policy line for the viewer page, terminator
     // included, or empty for no restriction at all.
     QByteArray frameAncestorsHeader() const;
+    // The Access-Control-* lines for a request from this Origin, or empty when
+    // the origin was never named by --embed-origin.
+    QByteArray corsHeadersFor(const QString &origin) const;
 
     QTcpServer *m_server;
     quint16 m_port;

--- a/src/http/http_server.h
+++ b/src/http/http_server.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QTcpServer>
 
 class AnoaBrowser;
@@ -18,6 +19,11 @@ public:
     bool start();
     void stop();
 
+    // Which origins may put the live view in an iframe. Empty is the default
+    // and means 'self' only — see frameAncestorsHeader() for why that is the
+    // default rather than the permissive thing.
+    void setEmbedOrigins(const QStringList &origins) { m_embedOrigins = origins; }
+
 private slots:
     void handleNewConnection();
 
@@ -32,6 +38,9 @@ private:
     // tab as a silent consolation, because a caller that named the wrong tab
     // has to find out.
     QWebEngineView *resolveRenderTab(const QUrlQuery &query, QString *badId) const;
+    // The Content-Security-Policy line for the viewer page, terminator
+    // included, or empty for no restriction at all.
+    QByteArray frameAncestorsHeader() const;
 
     QTcpServer *m_server;
     quint16 m_port;
@@ -39,4 +48,5 @@ private:
     quint16 m_proxyPort;
     QString m_authToken;
     AnoaBrowser *m_browser;
+    QStringList m_embedOrigins;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -341,6 +341,7 @@ int main(int argc, char *argv[])
     const auto wsPort    = static_cast<quint16>(config.port + 2);
 
     HttpServer httpServer(httpPort, debugPort, wsPort, config.authToken, &browser, &app);
+    httpServer.setEmbedOrigins(config.embedOrigins);
     if (!httpServer.start()) {
         qCritical("Failed to bind HTTP server to port %u (already in use?)", httpPort);
         return 1;

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -1,5 +1,5 @@
 import { spawn, execFileSync } from 'child_process';
-import { createConnection, createServer } from 'net';
+import { createConnection, createServer, Socket } from 'net';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import WebSocket from 'ws';
@@ -72,15 +72,67 @@ export function freePort() {
  * Start the anoa binary and wait for HTTP port to be ready.
  * Returns the child process.
  */
+/**
+ * Wait until nothing is listening on a port.
+ *
+ * waitForPort() answers as soon as the port accepts, which is the wrong question
+ * when a browser is still on its way out: the previous instance is still
+ * listening, the new one loses the bind and dies, and every assertion that
+ * follows is measured against the wrong process. That failure has shown up as
+ * "expected 200 to be 401" — the old browser, which had no auth token — and as
+ * a whole file's worth of cases silently marked skipped, because vitest reports
+ * a beforeAll that threw as a skip rather than a failure.
+ */
+export function waitForPortFree(port, timeout = 10000) {
+  const deadline = Date.now() + timeout;
+  return new Promise((resolve, reject) => {
+    function attempt() {
+      const sock = new Socket();
+      sock.setTimeout(500);
+      const retry = () => {
+        sock.destroy();
+        if (Date.now() >= deadline)
+          return reject(new Error(`Port ${port} still bound after ${timeout}ms`));
+        setTimeout(attempt, 100);
+      };
+      sock.once('connect', retry);            // still listening
+      sock.once('timeout', retry);
+      sock.once('error', () => { sock.destroy(); resolve(); }); // refused = free
+      sock.connect(port, '127.0.0.1');
+    }
+    attempt();
+  });
+}
+
 export async function startBrowser(extraArgs = []) {
+  // The port has to be ours before we ask for it, or we bind nothing and talk
+  // to whatever is still there.
+  await waitForPortFree(HTTP_PORT);
+
   const args = ['--headless', '--no-sandbox', `--port=${HTTP_PORT}`, ...extraArgs];
   const proc = spawn(BINARY, args, {
     env: { ...process.env, QPA_PLATFORM: 'offscreen' },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
+  let stderr = '';
   proc.stdout.on('data', (d) => process.env.ANOA_VERBOSE && process.stdout.write(d));
-  proc.stderr.on('data', (d) => process.env.ANOA_VERBOSE && process.stderr.write(d));
-  await waitForPort(HTTP_PORT, 15000);
+  proc.stderr.on('data', (d) => {
+    stderr += d;
+    if (process.env.ANOA_VERBOSE) process.stderr.write(d);
+  });
+
+  // A browser that dies on startup would otherwise be waited on for the full
+  // timeout and then reported as a port problem, with the reason it actually
+  // gave thrown away.
+  const died = new Promise((_, reject) => {
+    proc.once('exit', (code) => {
+      reject(new Error(`anoa exited with ${code} before binding ${HTTP_PORT}`
+                       + (stderr ? `: ${stderr.trim().split('\n').slice(-3).join(' | ')}` : '')));
+    });
+  });
+  died.catch(() => {}); // an exit after a successful start is not an error
+
+  await Promise.race([waitForPort(HTTP_PORT, 15000), died]);
   return proc;
 }
 
@@ -113,9 +165,22 @@ export function openWs(path = '', token = null) {
  * Returns { ws, targetId }.
  */
 export async function openDevtoolsWs(token = null) {
-  const resp = await fetch(`${BASE_URL}/json/list`);
-  const list = await resp.json();
-  if (!list.length) throw new Error('/json/list returned empty array');
+  // /json/list is legitimately empty for a moment after startup: a tab is built
+  // before its Chromium target exists, and the list is assembled from tabs whose
+  // target id has resolved. Binding the HTTP port — all startBrowser waits for —
+  // happens first, so asking straight away is a race that a loaded machine
+  // loses. It surfaced as a whole file reported "skipped" with zero failures,
+  // because vitest calls a beforeAll that threw a skip.
+  const deadline = Date.now() + 15000;
+  let list = [];
+  for (;;) {
+    const resp = await fetch(`${BASE_URL}/json/list`);
+    list = await resp.json();
+    if (list.length) break;
+    if (Date.now() >= deadline)
+      throw new Error('/json/list stayed empty for 15s');
+    await new Promise((r) => setTimeout(r, 150));
+  }
   const target = list[0];
   // The URL returned in webSocketDebuggerUrl already points to our proxy port.
   const wsUrl = token

--- a/tests/integration/live_view.test.js
+++ b/tests/integration/live_view.test.js
@@ -171,11 +171,82 @@ describe('Live view — pointer endpoints', () => {
     expect(await evalIn(tabId, 'document.getElementById("i").value')).toBe('halo dunia');
   });
 
+  // LV-07b — the assertion whose absence let a broken endpoint answer "scrolled"
+  // for as long as it has existed. Nothing checked that the page moved.
+  //
+  // It was broken on macOS only: there is no phaseless wheel there, so Qt sends
+  // scroll input as a gesture and QtWebEngine maps Qt::NoScrollPhase to a Blink
+  // phase Chromium discards. The event was posted, accepted, and dropped before
+  // the page ever saw it. Linux/aarch64 scrolled correctly the whole time,
+  // which is why running only on Linux would not have caught it.
+  it('scrolling actually moves the page, in both directions', async () => {
+    const tabs = await listTabs();
+    const tabId = tabs[0].anoaTabId;
+    // A document tall enough to scroll, built here rather than fetched so the
+    // test does not depend on the network.
+    await evalIn(tabId, `document.body.innerHTML =
+      '<div style="height:6000px">tinggi</div>'; window.scrollTo(0, 0); 'ready'`);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(await evalIn(tabId, 'window.scrollY')).toBe(0);
+
+    // Negative dy scrolls down — angle-delta convention, positive is up.
+    expect((await post(`/render/scroll?tab=${tabId}&dy=-600&x=400&y=300`)).status).toBe(200);
+    await new Promise((r) => setTimeout(r, 1200));
+    const down = await evalIn(tabId, 'window.scrollY');
+    expect(down).toBeGreaterThan(0);
+
+    await post(`/render/scroll?tab=${tabId}&dy=600&x=400&y=300`);
+    await new Promise((r) => setTimeout(r, 1200));
+    expect(await evalIn(tabId, 'window.scrollY')).toBeLessThan(down);
+  }, 20000);
+
+  // LV-07c — and the page must see a real wheel event, not just end up moved.
+  // A page that scrolls its own container listens for this.
+  it('the page receives a wheel event', async () => {
+    const tabs = await listTabs();
+    const tabId = tabs[0].anoaTabId;
+    await evalIn(tabId, `window.__wheel = 0;
+      window.addEventListener('wheel', () => { window.__wheel++; }, { passive: true });
+      'ready'`);
+    await post(`/render/scroll?tab=${tabId}&dy=-240&x=400&y=300`);
+    await new Promise((r) => setTimeout(r, 600));
+    expect(await evalIn(tabId, 'window.__wheel')).toBeGreaterThan(0);
+  });
+
   // LV-07
   it('function keys are accepted', async () => {
     expect((await post('/render/key?key=f5')).status).toBe(200);
     expect((await post('/render/key?key=f12')).status).toBe(200);
     expect((await post('/render/key?key=f13')).status).toBe(400);
+  });
+});
+
+describe('Live view — inspecting the page it streams', () => {
+  let proc;
+
+  beforeAll(async () => { proc = await startBrowser(); }, 20000);
+  afterAll(() => stopBrowser(proc));
+
+  // LV-07d — the Inspect button stands nothing up: it points at Chromium's own
+  // DevTools, already served on the debugging port, talking to the page over
+  // the CDP proxy that webSocketDebuggerUrl already names. This is the server
+  // fact the button depends on, so it is the part worth pinning.
+  it('Chromium DevTools is served on the debugging port', async () => {
+    const resp = await fetch(`http://localhost:${HTTP_PORT + 1}/devtools/inspector.html`);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get('content-type')).toMatch(/text\/html/);
+  });
+
+  // LV-07e
+  it('every tab publishes the socket DevTools attaches to', async () => {
+    const tabs = await listTabs();
+    expect(tabs.length).toBeGreaterThan(0);
+    for (const t of tabs) {
+      // The proxy port, not the raw debugging port — the proxy is where the
+      // auth token is enforced.
+      expect(t.webSocketDebuggerUrl).toMatch(
+        new RegExp(`^ws://[^/]+:${HTTP_PORT + 2}/devtools/page/`));
+    }
   });
 });
 

--- a/tests/integration/live_view.test.js
+++ b/tests/integration/live_view.test.js
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fetch from 'node-fetch';
+import WebSocket from 'ws';
+import net from 'node:net';
+import {
+  startBrowser, stopBrowser, BASE_URL, HTTP_PORT,
+  newTab, listTabs, getWsDebuggerUrl, sendCdp,
+} from './helpers.js';
+
+/**
+ * The live view: /render as something you can drive, not just watch.
+ *
+ * The endpoints under test are the ones a pointer needs and a click endpoint
+ * cannot provide — a press that outlives one event, a move that carries what is
+ * held, and a stream that shows the tab you asked for rather than the one that
+ * happens to be raised.
+ */
+
+const post = (path) => fetch(`${BASE_URL}${path}`, { method: 'POST' });
+
+/** Run an expression in a tab and hand back its value. */
+async function evalIn(tabId, expression) {
+  const targets = await listTabs();
+  const target = targets.find((t) => t.anoaTabId === tabId);
+  const ws = new WebSocket(target.webSocketDebuggerUrl);
+  await new Promise((res, rej) => { ws.once('open', res); ws.once('error', rej); });
+  try {
+    const r = await sendCdp(ws, 'Runtime.evaluate', { expression, returnByValue: true }, 7001);
+    return r.result?.result?.value;
+  } finally {
+    ws.close();
+  }
+}
+
+/**
+ * Read exactly one JPEG out of the multipart stream and hand back its bytes.
+ *
+ * Raw sockets rather than fetch(): the stream never ends, so anything that
+ * waits for a body waits forever.
+ */
+function firstFrame(query = '') {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection(HTTP_PORT, '127.0.0.1');
+    const timer = setTimeout(() => { sock.destroy(); reject(new Error('no frame in 15s')); }, 15000);
+    let buf = Buffer.alloc(0);
+    let need = -1;
+    let body = null;
+
+    sock.on('connect', () => {
+      sock.write(`GET /render/stream.mjpeg${query} HTTP/1.1\r\nHost: localhost\r\n\r\n`);
+    });
+    sock.on('error', (e) => { clearTimeout(timer); reject(e); });
+    sock.on('data', (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (body === null) {
+        // Response headers, then the first part's own headers.
+        const end = buf.indexOf('\r\n\r\n');
+        if (end < 0) return;
+        const rest = buf.subarray(end + 4);
+        const partEnd = rest.indexOf('\r\n\r\n');
+        if (partEnd < 0) return;
+        const partHdr = rest.subarray(0, partEnd).toString();
+        const m = /content-length:\s*(\d+)/i.exec(partHdr);
+        if (!m) { clearTimeout(timer); sock.destroy(); reject(new Error('no part length')); return; }
+        need = parseInt(m[1], 10);
+        body = rest.subarray(partEnd + 4);
+      } else {
+        body = Buffer.concat([body, chunk]);
+      }
+      if (body && body.length >= need) {
+        clearTimeout(timer);
+        sock.destroy();
+        resolve(body.subarray(0, need));
+      }
+    });
+  });
+}
+
+describe('Live view — pointer endpoints', () => {
+  let proc;
+
+  beforeAll(async () => { proc = await startBrowser(); }, 20000);
+  afterAll(() => stopBrowser(proc));
+
+  // LV-01
+  it('GET /render/viewport reports the tab size the input endpoints speak', async () => {
+    const resp = await fetch(`${BASE_URL}/render/viewport`);
+    expect(resp.status).toBe(200);
+    const j = await resp.json();
+    expect(j.width).toBeGreaterThan(0);
+    expect(j.height).toBeGreaterThan(0);
+    // The frame is device pixels and the coordinates are not, so a client that
+    // assumed they were the same would be wrong by exactly this factor.
+    expect(j.dpr).toBeGreaterThan(0);
+  });
+
+  // LV-02
+  it('move, mousedown and mouseup each accept a well-formed request', async () => {
+    for (const path of ['/render/move?x=10&y=10',
+                        '/render/mousedown?x=10&y=10',
+                        '/render/mouseup?x=10&y=10']) {
+      expect((await post(path)).status, path).toBe(200);
+    }
+  });
+
+  // LV-03
+  it('the pointer endpoints refuse coordinates and buttons they cannot honour', async () => {
+    expect((await post('/render/move?x=-1&y=10')).status).toBe(400);
+    expect((await post('/render/mousedown?x=10')).status).toBe(400);
+    expect((await post('/render/mouseup?x=10&y=10&button=elbow')).status).toBe(400);
+  });
+
+  // LV-04 — the whole reason these exist. A click endpoint cannot express a
+  // press that is still held while the pointer moves, which is what selecting
+  // text and dragging an element both are.
+  it('a press, a move and a release arrive as a drag, not as three clicks', async () => {
+    const tabs = await listTabs();
+    const tabId = tabs[0].anoaTabId;
+    await evalIn(tabId, `window.__log = [];
+      for (const t of ['mousemove', 'mousedown', 'mouseup', 'click'])
+        document.addEventListener(t, e => window.__log.push(t + ':' + e.clientX + ',' + e.clientY + ':b' + e.buttons));
+      'ready'`);
+
+    await post('/render/mousedown?x=60&y=50');
+    await post('/render/move?x=200&y=120&buttons=left');
+    await post('/render/mouseup?x=200&y=120');
+    await new Promise((r) => setTimeout(r, 400));
+
+    const log = await evalIn(tabId, 'window.__log.join("|")');
+    expect(log).toContain('mousedown:60,50:b1');
+    // The move carries the held button through — without it Chromium reads a
+    // drag as a hover and no selection ever starts.
+    expect(log).toContain('mousemove:200,120:b1');
+    expect(log).toContain('mouseup:200,120:b0');
+    // down + up at one point is still a click, so nothing regressed for callers
+    // that only ever wanted one.
+    expect(log).toContain('click:200,120');
+  });
+
+  // LV-05
+  it('modifiers reach the page', async () => {
+    const tabs = await listTabs();
+    const tabId = tabs[0].anoaTabId;
+    await evalIn(tabId, `window.__mods = '';
+      document.addEventListener('mousemove', e => {
+        window.__mods = (e.ctrlKey ? 'C' : '') + (e.shiftKey ? 'S' : '') + (e.altKey ? 'A' : '');
+      }); 'ready'`);
+    await post('/render/move?x=90&y=70&mods=ctrl,shift');
+    await new Promise((r) => setTimeout(r, 400));
+    expect(await evalIn(tabId, 'window.__mods')).toBe('CS');
+  });
+
+  // LV-06 — Ctrl+A was unreachable before: the key table held fourteen names
+  // and no modifier, so every shortcut a page defines was undriveable.
+  it('a letter with a modifier is a shortcut, not typed text', async () => {
+    const tabs = await listTabs();
+    const tabId = tabs[0].anoaTabId;
+    await evalIn(tabId, `document.body.innerHTML = '<input id=i>';
+      document.getElementById('i').focus(); 'ready'`);
+
+    await post('/render/type?text=halo%20dunia');
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await evalIn(tabId, 'document.getElementById("i").value')).toBe('halo dunia');
+
+    await post('/render/key?key=a&mods=ctrl');
+    await new Promise((r) => setTimeout(r, 300));
+    const selected = await evalIn(tabId,
+      'const i = document.getElementById("i"); i.value.substring(i.selectionStart, i.selectionEnd)');
+    expect(selected).toBe('halo dunia');
+    // And the shortcut must not also insert an "a".
+    expect(await evalIn(tabId, 'document.getElementById("i").value')).toBe('halo dunia');
+  });
+
+  // LV-07
+  it('function keys are accepted', async () => {
+    expect((await post('/render/key?key=f5')).status).toBe(200);
+    expect((await post('/render/key?key=f12')).status).toBe(200);
+    expect((await post('/render/key?key=f13')).status).toBe(400);
+  });
+});
+
+describe('Live view — the stream follows ?tab=', () => {
+  let proc;
+
+  beforeAll(async () => { proc = await startBrowser(); }, 20000);
+  afterAll(() => stopBrowser(proc));
+
+  // LV-08 — the bug this suite was written for. The stream grabbed the
+  // container, which is whatever tab is raised, so ?tab= was accepted and then
+  // ignored: asking for a background tab silently streamed the active one.
+  it('streams the tab that was asked for, not the active one', async () => {
+    const first = (await listTabs())[0].anoaTabId;
+    const { tabId: second } = await newTab('about:blank');
+    expect(second).toBeTruthy();
+
+    await evalIn(first, "document.body.style.background = '#ff0000'; 'ok'");
+    await evalIn(second, "document.body.style.background = '#0000ff'; 'ok'");
+    await new Promise((r) => setTimeout(r, 500));
+
+    const a = await firstFrame(`?tab=${first}`);
+    const b = await firstFrame(`?tab=${second}`);
+    const aAgain = await firstFrame(`?tab=${first}`);
+
+    // Same tab twice is byte-identical, which is what makes the comparison
+    // below mean "different tab" rather than "different moment".
+    expect(aAgain.equals(a)).toBe(true);
+    expect(b.equals(a)).toBe(false);
+  });
+
+  // LV-09
+  it('an unknown tab is refused rather than silently served the active one', async () => {
+    const resp = await fetch(`${BASE_URL}/render/stream.mjpeg?tab=t99`);
+    expect(resp.status).toBe(404);
+  });
+});
+
+describe('Live view — tabs from the viewer', () => {
+  let proc;
+
+  beforeAll(async () => { proc = await startBrowser(); }, 20000);
+  afterAll(() => stopBrowser(proc));
+
+  // LV-10
+  it('POST /render/tab/new opens a tab that /json/list then reports', async () => {
+    const resp = await post('/render/tab/new');
+    expect(resp.status).toBe(200);
+    const { id } = await resp.json();
+    expect(id).toMatch(/^t[1-9][0-9]*$/);
+    const tabs = await listTabs();
+    expect(tabs.map((t) => t.anoaTabId)).toContain(id);
+  });
+
+  // LV-11
+  it('POST /render/tab/close closes that tab and refuses the last one', async () => {
+    const { id } = await (await post('/render/tab/new')).json();
+    expect((await post(`/render/tab/close?tab=${id}`)).status).toBe(200);
+    expect((await listTabs()).map((t) => t.anoaTabId)).not.toContain(id);
+
+    // Down to one: closing it would leave a browser with no page, which the
+    // registry refuses for the same reason the CLI does.
+    const remaining = await listTabs();
+    for (const t of remaining.slice(1))
+      await post(`/render/tab/close?tab=${t.anoaTabId}`);
+    const last = (await listTabs())[0].anoaTabId;
+    expect((await post(`/render/tab/close?tab=${last}`)).status).toBe(409);
+  });
+
+  // LV-12
+  it('POST /render/tab/close needs a tab named', async () => {
+    expect((await post('/render/tab/close')).status).toBe(400);
+  });
+});
+
+describe('Live view — who may frame it', () => {
+  // LV-13 — the view forwards keystrokes as well as showing pixels, so a page
+  // that can frame it can read a logged-in session and act inside it.
+  it('names an allowed origin when one is configured', async () => {
+    const proc = await startBrowser(['--embed-origin', 'https://app.example.com']);
+    try {
+      const resp = await fetch(`${BASE_URL}/render`);
+      expect(resp.headers.get('content-security-policy'))
+        .toBe("frame-ancestors 'self' https://app.example.com");
+    } finally {
+      await stopBrowser(proc);
+    }
+  }, 20000);
+
+  // LV-14
+  it('drops the restriction entirely for --embed-origin "*"', async () => {
+    const proc = await startBrowser(['--embed-origin', '*']);
+    try {
+      const resp = await fetch(`${BASE_URL}/render`);
+      expect(resp.headers.get('content-security-policy')).toBeNull();
+    } finally {
+      await stopBrowser(proc);
+    }
+  }, 20000);
+});

--- a/tests/integration/live_view.test.js
+++ b/tests/integration/live_view.test.js
@@ -276,3 +276,56 @@ describe('Live view — who may frame it', () => {
     }
   }, 20000);
 });
+
+describe('Live view — reading the tab list from the host page', () => {
+  const HOST = 'http://127.0.0.1:8080';
+  let proc;
+
+  beforeAll(async () => {
+    proc = await startBrowser(['--embed-origin', HOST]);
+  }, 20000);
+  afterAll(() => stopBrowser(proc));
+
+  // LV-15 — an origin trusted to embed the view and drive the browser through
+  // it, but not to read /json/list, can show the view and cannot draw a tab bar
+  // around it. That is most of what embedding is for, so the two travel
+  // together.
+  it('answers an allowed origin with its own origin echoed back', async () => {
+    const resp = await fetch(`${BASE_URL}/json/list`, { headers: { Origin: HOST } });
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get('access-control-allow-origin')).toBe(HOST);
+    // Or a cache hands one origin's answer to another.
+    expect(resp.headers.get('vary')).toBe('Origin');
+  });
+
+  // LV-16
+  it('says nothing to an origin that was never named', async () => {
+    const resp = await fetch(`${BASE_URL}/json/list`,
+                             { headers: { Origin: 'https://elsewhere.example' } });
+    expect(resp.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  // LV-17
+  it('answers a preflight, which carries no credentials of its own', async () => {
+    const resp = await fetch(`${BASE_URL}/render/tab/new`,
+                             { method: 'OPTIONS', headers: { Origin: HOST } });
+    expect(resp.status).toBe(204);
+    expect(resp.headers.get('access-control-allow-methods')).toContain('POST');
+  });
+});
+
+describe('Live view — CORS stays off until asked for', () => {
+  let proc;
+
+  beforeAll(async () => { proc = await startBrowser(); }, 20000);
+  afterAll(() => stopBrowser(proc));
+
+  // LV-18 — the default configuration answers exactly as it did before this
+  // existed, for every origin.
+  it('sends no CORS headers when no origin was configured', async () => {
+    const resp = await fetch(`${BASE_URL}/json/list`,
+                             { headers: { Origin: 'http://127.0.0.1:8080' } });
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get('access-control-allow-origin')).toBeNull();
+  });
+});

--- a/tests/integration/render_endpoints.test.js
+++ b/tests/integration/render_endpoints.test.js
@@ -138,10 +138,18 @@ describe('Render endpoints (no auth)', () => {
     expect(resp.headers.get('content-type')).toMatch(/text\/html/);
   });
 
-  // RND-17
-  it('GET /render page body references /render/screenshot.png', async () => {
+  // RND-17. The page polled a PNG every 500 ms when it was a picture of a
+  // browser. It is a live view now, so it opens the MJPEG stream instead.
+  it('GET /render page body opens the MJPEG stream', async () => {
     const body = await fetch(`${BASE_URL}/render`).then(r => r.text());
-    expect(body).toContain('/render/screenshot.png');
+    expect(body).toContain('/render/stream.mjpeg');
+  });
+
+  // RND-17b — the view forwards input, so a page that can frame it can drive
+  // the browser. Same-origin only unless an origin is named on the command line.
+  it('GET /render restricts framing to same-origin by default', async () => {
+    const resp = await fetch(`${BASE_URL}/render`);
+    expect(resp.headers.get('content-security-policy')).toBe("frame-ancestors 'self'");
   });
 
   // RND-19
@@ -254,13 +262,18 @@ describe('Render endpoints (with auth token)', () => {
     expect(resp.status).toBe(401);
   });
 
-  // RND-18
-  it('GET /render with auth configured embeds token in screenshot URL', async () => {
+  // RND-18. The page used to have the server's token substituted into it, so
+  // every authenticated fetch of /render returned a document with the secret
+  // written in it. It is served verbatim now and the viewer reads the token
+  // from its own query string, which is the one the client already holds —
+  // so the token must NOT appear in the body.
+  it('GET /render does not write the auth token into the page', async () => {
     const resp = await fetch(`${BASE_URL}/render`, {
       headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
     });
     const body = await resp.text();
-    expect(body).toContain(`token=${AUTH_TOKEN}`);
+    expect(resp.status).toBe(200);
+    expect(body).not.toContain(AUTH_TOKEN);
   });
 });
 


### PR DESCRIPTION
`/render` was a picture of a browser — an `<img>` repointed at `/render/screenshot.png` every 500 ms, no input, no tabs. It is a handle on one now: an MJPEG stream you can click, drag, type and scroll in, with a tab bar, a URL bar and an Inspect button, designed to go in an `<iframe>`.

```html
<iframe src="http://localhost:9222/render?embed=1&tab=t2&token=…"
        width="1280" height="720" style="border:0"></iframe>
```

`?tab=<id>` picks which tab the frame drives, so two frames on two ids drive two tabs at once — the agent's tab and the user's, side by side. `?embed=1` drops the chrome so the host app draws its own. A worked example is in `examples/embed/`.

## Input primitives that did not exist

A click endpoint can drive a page from a script; it cannot be driven by a pointer.

- **`sendMouseMove` / `sendMouseDown` / `sendMouseUp`** — hover state is what opens a menu, and a press held across moves is what selecting text and dragging an element are. `?buttons=` carries what is still held, which is the whole difference between a drag and a hover.
- **Modifiers everywhere.** Ctrl+A was unreachable: the key table held fourteen names and no modifier at all. It now also accepts `f1`–`f12` and single characters, and suppresses the text payload for a shortcut so Ctrl+A does not both select all *and* type an `a`.

## Four bugs found while building it

**Scroll never worked on macOS — for as long as the endpoint has existed.** `/render/scroll` answered `200 scrolled` and the page did not move; it did not even receive a `wheel` event. macOS has no phaseless wheel: Qt delivers scroll input as a gesture, and QtWebEngine maps `Qt::NoScrollPhase` to a Blink phase Chromium discards, so the event was posted, accepted and dropped before the page saw it. Confirmed platform-specific by running the *released* v0.10.1 AppImage on an RK3588 board, where the same code scrolled correctly. The fix sends the begin/update/end sequence macOS expects with `pixelDelta` filled in; the ratio is measured, not guessed — 600 angle units moved the page 300 px on Linux, so `pixelDelta = angleDelta/2` and both platforms now scroll the same distance. **Nothing in the suite checked that the page moved.** LV-07b/07c now do, in both directions and including the DOM `wheel` event.

**The stream ignored `?tab=`.** `/render/stream.mjpeg` called `browser->grab()`, which grabs the container and therefore whatever tab is raised. The tab was resolved, a bad id was 404'd correctly, and then the answer was thrown away — asking for a background tab streamed the active one, with nothing anywhere to say so. LV-08 proves frames differ between tabs *and* that two grabs of the same tab are byte-identical, so the comparison means "different tab" rather than "different moment".

**A frame is device pixels; every input endpoint is logical pixels.** On a HiDPI display a client mapping a click through the image it was handed lands at double the intended point, on a page that looks like it ignored the click. `GET /render/viewport` now answers with the logical size.

**An embedding origin could not read the tab list.** `--embed-origin` let an origin frame the view and drive the browser through it, but a `fetch` to `/json/list` was still refused — no CORS headers were ever sent. So a host page could show the view and could not draw a tab bar around it, which is most of what embedding is for. Found by writing the example, not by the endpoint tests, which call the server with no `Origin` at all.

## Inspect element was already there and had no door

Chromium's DevTools frontend is served on the debugging port and talks to the page over the CDP proxy — exactly what `webSocketDebuggerUrl` already names. Nothing is stood up: the viewer and the example app each gained an **Inspect** button that opens it in a new window, because DevTools inside an 860px frame is not usable.

## Embedding is opt-in by origin

The view forwards keystrokes as well as showing pixels, so a page that can frame it can watch a logged-in session and act inside it. Default is `Content-Security-Policy: frame-ancestors 'self'`; `--embed-origin` widens it (repeatable, `'*'` removes it) and also allows that origin to read the JSON endpoints. Verified both directions against a real cross-origin host page by screenshot rather than by trusting the header: a refused frame renders Chromium's broken-document icon, an allowed one renders the viewer.

The old page also had the server's auth token substituted into it, so every authenticated `GET /render` returned a document with the secret written in it. The page is static now and reads the token from its own query string. RND-18 was inverted to assert the token does **not** appear in the body.

## Two test-harness weaknesses, because green runs were lying

- vitest reports a `beforeAll` that threw as **skipped**, not failed — a whole file (pdf_handler's ten cases) vanished behind "0 failed". `openDevtoolsWs` now waits for `/json/list` instead of asking once: the list is legitimately empty for a moment after startup, because a tab exists before its Chromium target does and `startBrowser` only waits for the HTTP port to bind.
- `startBrowser` now waits for the port to be free before spawning, and reports a browser that died on startup with the reason it gave rather than blaming the port after a 15s timeout.

Result: 118 integration cases actually run, where 108 did before.

## Verified

| suite | result |
|---|---|
| integration (vitest) | 118 passed, 21 skipped, 0 failed — 22 new in `live_view.test.js` |
| port layout / extensions | 13 / 4 passed |
| unit (ctest) | 4 passed |
| puppeteer / playwright | 9 / 14 passed |
| regression smoke | 5 passed |

**On real ARM hardware** (RK3588, Debian 12), using an aarch64 AppImage built from this branch: scroll in both directions with no regression from the macOS-only change, drag with the button held, Ctrl modifier, per-tab streaming, CSP, CORS, DevTools on the debugging port, and the `examples/embed/` app running end to end with its own tab bar.

Coordinate fidelity was checked by running the viewer *inside anoa itself* and clicking through it: (300,200), (640,360) and (100,50) each arrived exactly. A drag through the embedded viewer selected precisely the intended sentence in the target tab.