### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(anoa VERSION 0.10.1 LANGUAGES CXX)
+project(anoa VERSION 0.11.0 LANGUAGES CXX)
 
 # CI injects the git tag here so the tag is the single source of truth for the
 # version — CMakeLists.txt never needs a manual bump for releases. The value


### PR DESCRIPTION
Minor release — the live view at `/render` became interactive and embeddable (#18), and four bugs it uncovered were fixed along the way, including a scroll path that had never worked on macOS.

Release dry-run on this branch: all four platform builds green, AppImage smoke tests pass on x86_64 and aarch64 including the bare-container runs.