### PR TITLE
chore(release): 0.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(anoa VERSION 0.11.0 LANGUAGES CXX)
+project(anoa VERSION 0.12.0 LANGUAGES CXX)
 
 # CI injects the git tag here so the tag is the single source of truth for the
 # version — CMakeLists.txt never needs a manual bump for releases. The value

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
       # Keep this in step with CMakeLists.txt. It is passed to the build rather
       # than read from it, so `nix run` reports the same string a release does.
-      version = "0.11.0";
+      version = "0.12.0";
     in
     {
       packages = forEach (pkgs: rec {

--- a/pages/index.html
+++ b/pages/index.html
@@ -39,7 +39,7 @@
         or any CDP client. One binary, no driver to install, no headless-versus-real
         distinction to reason about.</p>
         <div class="badges">
-          <span>latest <b>v0.11.0</b></span>
+          <span>latest <b>v0.12.0</b></span>
           <span>macOS · Linux · Windows</span>
           <span>x86_64 · <b>aarch64</b></span>
           <span>Qt 6 + Chromium</span>
@@ -104,7 +104,7 @@
 
 <section id="watch">
   <div class="col">
-    <p class="eyebrow">Live view · new in v0.11.0</p>
+    <p class="eyebrow">Live view</p>
     <h2>Watch it work — and hand the controls over</h2>
     <p><code>/render</code> is a page. Open it in any browser and you get the live
     stream of a tab you can <strong>click, drag, type and scroll in</strong>, with a

--- a/pages/llms.txt
+++ b/pages/llms.txt
@@ -17,7 +17,7 @@ Also packaged as a Nix flake for x86_64-linux, aarch64-linux and aarch64-darwin
 has no qtwebengine for x86_64-darwin, so Intel Macs use Homebrew. Flakes are
 still experimental, so a fresh Nix needs `experimental-features = nix-command
 flakes` in ~/.config/nix/nix.conf before any of those commands work.
-`anoa terminal` is POSIX-only. Latest release: v0.11.0.
+`anoa terminal` is POSIX-only. Latest release: v0.12.0.
 
 ## Start here
 


### PR DESCRIPTION
Minor release. Two features since 0.11.0:

- **Nix flake** — `nix run github:porcupine-md/anoa-browser`, built for x86_64-linux, aarch64-linux and aarch64-darwin, tested on real ARM hardware
- **`--max-renderers <n>`** — caps Chromium's renderer processes, which is where the memory of many tabs lives: nine tabs measured 1031 MB of renderers, 355 MB with `--max-renderers 3`

`flake.nix` carries the version separately from `CMakeLists.txt`, so both move together or `nix run` reports a version no release ever had. The site badge, `llms.txt` and the live-view eyebrow move with them.

Release dry-run on this branch: four platform builds green, AppImage smoke tests pass on x86_64 and aarch64 including the bare-container runs.