### PR TITLE
feat(browser): --proxy and --proxy-bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,33 @@ request interception — `anoa network` observes, it cannot block or rewrite.
 
 ---
 
+## Going through a proxy
+
+The proxy belongs to the browser, and every tab in it goes through it.
+
+```bash
+anoa --headless --port 9222 --proxy http://proxy.example:3128 &
+anoa --headless --port 9222 --proxy socks5://127.0.0.1:1080 &
+anoa --headless --port 9222 --proxy http://user:pass@proxy.example:3128 \
+     --proxy-bypass "localhost,127.0.0.1,*.internal" &
+```
+
+`--proxy` takes `host:port` or `scheme://host:port`, where the scheme is `http`,
+`https`, `socks5` or `socks4`; a bare host gets `http://`. Anything else is
+refused at startup rather than accepted and then failing every request with a
+message that blames the site.
+
+Credentials go in the URL. Chromium's own `--proxy-server` takes none, so anoa
+passes it the origin and answers the proxy's authentication challenge itself —
+without that a password-protected proxy simply hangs, with nothing in the page
+to say a password was wanted.
+
+**There is no per-tab proxy.** Chromium keeps proxy settings per process and Qt
+exposes no way to vary them per page, so two proxies means two browsers on two
+ports, addressed with `--port`.
+
+---
+
 ## Memory with many tabs
 
 Chromium gives every tab its own renderer process, and that is where the memory

--- a/pages/docs.html
+++ b/pages/docs.html
@@ -42,6 +42,7 @@
         <li><a href="#start">Starting a browser</a></li>
         <li><a href="#reaching">Reaching one</a></li>
         <li><a href="#sessions">Sessions and profiles</a></li>
+        <li><a href="#proxy">Proxy</a></li>
         <li><a href="#memory">Memory, many tabs</a></li>
         <li><a href="#terminal-opts">Terminal viewer</a></li>
       </ul>
@@ -214,6 +215,8 @@ environment.systemPackages = [ inputs.anoa.packages.${system}.anoa ];</pre>
             <tr><td><code>--profile-dir &lt;dir&gt;</code></td><td>Where profiles live</td></tr>
             <tr><td><code>--ephemeral</code></td><td>Keep nothing: no cookies, no storage, gone when the process ends</td></tr>
             <tr><td><code>--download-dir &lt;dir&gt;</code></td><td>Where downloads are saved. Default is the platform's Downloads folder</td></tr>
+            <tr><td><code>--proxy &lt;url&gt;</code></td><td><code>host:port</code> or <code>scheme://host:port</code> — <code>http</code>, <code>https</code>, <code>socks5</code>, <code>socks4</code>. Credentials go in the URL. See <a href="#proxy">Going through a proxy</a></td></tr>
+            <tr><td><code>--proxy-bypass &lt;list&gt;</code></td><td>Hosts that skip the proxy, comma separated</td></tr>
             <tr><td><code>--max-renderers &lt;n&gt;</code></td><td>Cap Chromium renderer processes. Chromium gives each tab its own, which is where the memory goes; fewer processes is less memory and less parallelism — see <a href="#memory">Memory with many tabs</a></td></tr>
             <tr><td><code>--extension &lt;path&gt;</code></td><td>Load an unpacked Chromium extension (manifest v2). Repeatable</td></tr>
             <tr><td><code>--auth-token &lt;secret&gt;</code></td><td>Require this bearer token on CDP and on the HTTP endpoints</td></tr>
@@ -276,6 +279,31 @@ environment.systemPackages = [ inputs.anoa.packages.${system}.anoa ];</pre>
         <p style="margin-top:16px">Tabs share one jar unless asked otherwise, which is what
         makes two logins to the same site possible at once — see
         <code>tab new --profile</code> and <code>--isolated</code> below.</p>
+      </section>
+
+      <section id="proxy">
+        <h2>Going through a proxy</h2>
+        <p>The proxy belongs to the browser, and every tab in it goes through it.</p>
+<pre class="term"><span class="p">$</span> anoa --headless --port 9222 --proxy http://proxy.example:3128
+<span class="p">$</span> anoa --headless --port 9222 --proxy socks5://127.0.0.1:1080
+<span class="p">$</span> anoa --headless --port 9222 \
+      --proxy <b>http://user:pass@proxy.example:3128</b> \
+      --proxy-bypass <b>"localhost,127.0.0.1,*.internal"</b></pre>
+        <p style="margin-top:16px"><code>--proxy</code> takes <code>host:port</code> or
+        <code>scheme://host:port</code>, where the scheme is <code>http</code>,
+        <code>https</code>, <code>socks5</code> or <code>socks4</code>; a bare host gets
+        <code>http://</code>. Anything else is refused at startup rather than accepted and
+        then failing every request with a message that blames the site.</p>
+        <p>Credentials go in the URL. Chromium's own <code>--proxy-server</code> takes none,
+        so anoa passes it the origin and answers the proxy's authentication challenge itself
+        — without that a password-protected proxy simply hangs, and nothing in the page says
+        a password was wanted.</p>
+        <div class="note">
+          <p><strong>There is no per-tab proxy.</strong> Chromium keeps proxy settings per
+          process and Qt exposes no way to vary them per page — there is no proxy API on
+          <code>QWebEngineProfile</code> at all. Two proxies means two browsers on two ports,
+          addressed with <code>--port</code>.</p>
+        </div>
       </section>
 
       <section id="memory">

--- a/pages/llms.txt
+++ b/pages/llms.txt
@@ -60,7 +60,13 @@ rather than by a person.
 
 ## Options
 
-- Starting a browser: `--port`, `--headless`, `--no-sandbox`, `--width`, `--height`, `--profile`, `--profile-dir`, `--ephemeral`, `--download-dir`, `--extension`, `--auth-token`, `--embed-origin`, `--max-renderers`, `--config`
+- Starting a browser: `--port`, `--headless`, `--no-sandbox`, `--width`, `--height`, `--profile`, `--profile-dir`, `--ephemeral`, `--download-dir`, `--extension`, `--auth-token`, `--embed-origin`, `--max-renderers`, `--proxy`, `--proxy-bypass`, `--config`
+
+`--proxy` takes `host:port` or `scheme://host:port` (http, https, socks5,
+socks4), with credentials in the URL; `--proxy-bypass` lists hosts that skip
+it. The proxy belongs to the browser and every tab uses it — there is no
+per-tab proxy, because Chromium keeps proxy settings per process and Qt
+exposes none per page. Two proxies means two browsers on two ports.
 
 Memory scales with tabs because Chromium runs a renderer process per tab:
 measured, nine tabs cost 1031 MB of renderers against 117 MB for one, while the

--- a/src/agent/agent_help.cpp
+++ b/src/agent/agent_help.cpp
@@ -32,6 +32,9 @@ const Group kGroups[] = {
     --embed-origin <origin>         let this origin iframe the live view at
                                     /render (repeatable; default same-origin)
     --download-dir <dir>            where downloads land (default: Downloads)
+    --proxy <url>                   route the browser through a proxy:
+                                    host:port, or scheme://user:pass@host:port
+    --proxy-bypass <list>           hosts that skip it, comma separated
     --max-renderers <n>             cap Chromium renderer processes; fewer
                                     processes is less memory, less parallelism
     --config <file>                 JSON or INI file of the above

--- a/src/agent/agent_skill.cpp
+++ b/src/agent/agent_skill.cpp
@@ -155,6 +155,19 @@ anoa tab new example.com --isolated       # its own cookies, gone with the tab
 anoa tab new example.com --profile work   # its own cookies, kept on disk
 ```
 
+**A proxy belongs to the browser, not to a tab.** Set it when you start one:
+
+```bash
+anoa --headless --port 9222 --proxy http://user:pass@proxy.example:3128 &
+anoa --headless --port 9222 --proxy socks5://127.0.0.1:1080 \
+     --proxy-bypass "localhost,127.0.0.1,*.internal" &
+```
+
+Every tab in that browser goes through it — there is no per-tab proxy, because
+Chromium keeps proxy settings per process and Qt exposes no way to vary them per
+page. If you need two tabs on two different proxies, start two browsers on
+different ports and address them with `--port`.
+
 ## Things a page does that used to fail quietly
 
 `alert`, `confirm` and `prompt` are answered and recorded rather than shown:
@@ -192,6 +205,23 @@ somewhere else. `--tab <id>` picks which tab to act on; without it every command
 acts on the active tab.
 
 `<target>` below is either a ref from a snapshot (`@e2`) or any CSS selector.
+
+## Starting the browser
+
+| Flag | Does |
+|---|---|
+| `--headless` | no window, no display server needed |
+| `--port <n>` | which port to listen on (default 9222) |
+| `--profile <name>` | a named profile with its own cookies and storage |
+| `--ephemeral` | keep nothing; gone when the process ends |
+| `--proxy <url>` | `host:port`, or `scheme://user:pass@host:port` with `http`, `https`, `socks5`, `socks4` |
+| `--proxy-bypass <list>` | hosts that skip the proxy, comma separated |
+| `--max-renderers <n>` | cap renderer processes: less memory, less parallelism |
+| `--download-dir <dir>` | where downloads land |
+
+The proxy is a property of the browser, not of a tab: every tab in one browser
+uses it, and there is no per-tab proxy. Two proxies means two browsers on two
+ports.
 
 ## Tabs
 

--- a/src/browser/anoa_browser.cpp
+++ b/src/browser/anoa_browser.cpp
@@ -5,6 +5,7 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDir>
+#include <QAuthenticator>
 #include <QEventLoop>
 #include <QFile>
 #include <QKeyEvent>
@@ -202,6 +203,20 @@ AnoaBrowser::AnoaBrowser(const Config &config, QWidget *parent)
     // process each and 1061 ms sharing four, because a shared process has one
     // main thread. Off by default; the caller decides where on that curve they
     // want to sit.
+    // Chromium's --proxy-server takes no credentials, so only the origin goes
+    // here. Anything in the userinfo is answered from proxyAuthenticationRequired
+    // below — a proxy that wants a password and never gets one simply hangs, with
+    // nothing in the page to say why.
+    if (!m_config.proxyUrl.isEmpty()) {
+        const QUrl p(m_config.proxyUrl);
+        QString server = p.scheme() + QStringLiteral("://") + p.host();
+        if (p.port() > 0)
+            server += QStringLiteral(":") + QString::number(p.port());
+        flags += " --proxy-server=" + server.toUtf8();
+        if (!m_config.proxyBypass.isEmpty())
+            flags += " --proxy-bypass-list=" + m_config.proxyBypass.toUtf8();
+    }
+
     if (m_config.maxRenderers > 0)
         flags += " --renderer-process-limit=" + QByteArray::number(m_config.maxRenderers);
 
@@ -296,6 +311,24 @@ QWebEngineView *AnoaBrowser::createView(QWebEngineProfile *profile)
     auto *view = new QWebEngineView(this);
     acceptDownloadsOn(profile);
     auto *page = new AnoaPage(m_config.terminalMode, profile, view);
+
+    // Credentials for --proxy. Chromium asks once per proxy and caches the
+    // answer; leaving the signal unconnected means Qt cancels the request, so
+    // an authenticating proxy would fail every load with nothing in the page
+    // explaining that a password was wanted.
+    if (!m_config.proxyUrl.isEmpty()) {
+        const QUrl proxy(m_config.proxyUrl);
+        if (!proxy.userName().isEmpty()) {
+            connect(page, &QWebEnginePage::proxyAuthenticationRequired, this,
+                    [proxy](const QUrl &, QAuthenticator *auth, const QString &) {
+                        if (!auth)
+                            return;
+                        auth->setUser(proxy.userName());
+                        auth->setPassword(proxy.password());
+                    });
+        }
+    }
+
     // A popup becomes a background tab on the same profile: it is the same
     // session the opener belongs to, and putting it in front would interrupt
     // whoever is driving the active tab.

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -169,6 +169,12 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
     QCommandLineOption extensionOpt("extension", "Path to an unpacked extension directory (repeatable)", "path");
     QCommandLineOption authTokenOpt("auth-token", "Bearer token required for CDP WebSocket connections", "token");
     QCommandLineOption configOpt("config", "Path to JSON or INI config file", "file");
+    QCommandLineOption proxyOpt("proxy",
+        "Route the browser through a proxy: http://host:port, socks5://host:port, "
+        "or host:port. Credentials may be given as http://user:pass@host:port", "url");
+    QCommandLineOption proxyBypassOpt("proxy-bypass",
+        "Hosts that skip the proxy, comma separated, e.g. \"localhost,127.0.0.1,*.internal\"",
+        "list");
     QCommandLineOption maxRenderersOpt("max-renderers",
         "Cap Chromium renderer processes (default: one per tab). Trades parallelism for memory", "n");
     QCommandLineOption embedOriginOpt("embed-origin",
@@ -198,6 +204,8 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
     parser.addOption(authTokenOpt);
     parser.addOption(embedOriginOpt);
     parser.addOption(maxRenderersOpt);
+    parser.addOption(proxyOpt);
+    parser.addOption(proxyBypassOpt);
     parser.addOption(configOpt);
     parser.addOption(widthOpt);
     parser.addOption(heightOpt);
@@ -234,6 +242,27 @@ Config parseArgs(int /*argc*/, char * /*argv*/[], bool terminalMode)
         cfg.authToken = parser.value(authTokenOpt);
     if (parser.isSet(embedOriginOpt))
         cfg.embedOrigins = parser.values(embedOriginOpt);
+    if (parser.isSet(proxyOpt)) {
+        const QString raw = parser.value(proxyOpt).trimmed();
+        // A bare host:port is what most people type and what Chromium accepts,
+        // but QUrl reads "127.0.0.1:8080" as scheme "127.0.0.1". Give it a
+        // scheme before parsing so the check below tests the real thing.
+        const QString probe = raw.contains(QStringLiteral("://"))
+            ? raw : QStringLiteral("http://") + raw;
+        const QUrl u(probe);
+        static const QStringList kSchemes{QStringLiteral("http"), QStringLiteral("https"),
+                                          QStringLiteral("socks5"), QStringLiteral("socks4")};
+        if (raw.isEmpty() || !u.isValid() || u.host().isEmpty()
+            || !kSchemes.contains(u.scheme())) {
+            QTextStream err(stderr);
+            err << "Error: --proxy must be host:port or scheme://host:port, where scheme is "
+                << "http, https, socks5 or socks4; got " << raw << Qt::endl;
+            ::exit(1);
+        }
+        cfg.proxyUrl = probe;
+    }
+    if (parser.isSet(proxyBypassOpt))
+        cfg.proxyBypass = parser.value(proxyBypassOpt).trimmed();
     if (parser.isSet(maxRenderersOpt)) {
         bool ok = false;
         const int n = parser.value(maxRenderersOpt).toInt(&ok);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -22,6 +22,12 @@ struct Config {
     // means roughly one per tab. Lower numbers trade parallelism for memory —
     // see the comment in anoa_browser.cpp where it is applied.
     int maxRenderers = 0;
+    // --proxy. Held whole, credentials included: Chromium's --proxy-server
+    // takes no user:pass, so the host part goes on the command line and the
+    // credentials are answered from proxyAuthenticationRequired instead.
+    QString proxyUrl;
+    // Hosts that skip the proxy. Chromium's own list syntax, passed through.
+    QString proxyBypass;
     // Origins allowed to put the live view (/render) in an iframe. Empty means
     // 'self' only, because the view forwards input as well as showing pixels —
     // a page that can frame it can drive the browser. "*" opts out entirely.

--- a/tests/unit/test_config.cpp
+++ b/tests/unit/test_config.cpp
@@ -369,6 +369,39 @@ private slots:
         QCOMPARE(runParseArgs({}).cfg["maxRenderers"].toInt(), 0);
     }
 
+    // CFG-25: --proxy. A bare host:port is what people type and what Chromium
+    // accepts, but QUrl reads "127.0.0.1:8080" as scheme "127.0.0.1", so the
+    // scheme is filled in before validating and the stored value is normalised.
+    // Anything that is not a proxy scheme is refused up front: Chromium would
+    // take it, fail every request, and blame the site.
+    void testProxyIsValidatedAndNormalised()
+    {
+        QCOMPARE(runParseArgs({"--proxy", "ftp://h:1"}).exitCode, 1);
+        QCOMPARE(runParseArgs({"--proxy", "://broken"}).exitCode, 1);
+        QCOMPARE(runParseArgs({"--proxy", ""}).exitCode, 1);
+
+        const ParseResult bare = runParseArgs({"--proxy", "1.2.3.4:8080"});
+        QCOMPARE(bare.exitCode, 0);
+        QCOMPARE(bare.cfg["proxyUrl"].toString(), QString("http://1.2.3.4:8080"));
+
+        const ParseResult socks = runParseArgs({"--proxy", "socks5://1.2.3.4:1080"});
+        QCOMPARE(socks.exitCode, 0);
+        QCOMPARE(socks.cfg["proxyUrl"].toString(), QString("socks5://1.2.3.4:1080"));
+
+        // Credentials survive parsing: they are answered from the auth signal
+        // rather than put on Chromium's command line, so they must be kept.
+        const ParseResult creds = runParseArgs({"--proxy", "http://bob:s3cret@p.example:3128"});
+        QCOMPARE(creds.exitCode, 0);
+        QCOMPARE(creds.cfg["proxyUrl"].toString(),
+                 QString("http://bob:s3cret@p.example:3128"));
+
+        const ParseResult bypass =
+            runParseArgs({"--proxy", "1.2.3.4:8080", "--proxy-bypass", "localhost,*.internal"});
+        QCOMPARE(bypass.cfg["proxyBypass"].toString(), QString("localhost,*.internal"));
+
+        QCOMPARE(runParseArgs({}).cfg["proxyUrl"].toString(), QString());
+    }
+
     // TERM-CFG-12: --term-port and --fps reject a non-numeric value before the
     // range check ever runs. TERM-CFG-05/06/07 already cover the range refusals
     // (--term-port 0 and 70000, --fps 0); this is the branch above them.
@@ -624,6 +657,8 @@ static bool runHarnessIfRequested(int argc, char *argv[])
             {"profileName", cfg.profileName},
             {"width", cfg.width},
             {"maxRenderers", cfg.maxRenderers},
+            {"proxyUrl", cfg.proxyUrl},
+            {"proxyBypass", cfg.proxyBypass},
             {"height", cfg.height},
             {"extensionPaths", QJsonArray::fromStringList(cfg.extensionPaths)},
         };


### PR DESCRIPTION
Browser-level proxy support, plus the skill documents so an agent knows the shape of it.

```bash
anoa --headless --port 9222 --proxy http://proxy.example:3128 &
anoa --headless --port 9222 --proxy socks5://127.0.0.1:1080 &
anoa --headless --port 9222 --proxy-bypass "localhost,127.0.0.1,*.internal" &
```

`host:port` or `scheme://host:port` (http, https, socks5, socks4); a bare host gets `http://`. Anything else is refused at parse time — Chromium accepts a nonsense `--proxy-server` happily and then fails every request with an error that blames the site.

**Credentials** go in the URL and stay off Chromium's command line, which takes none. anoa passes the origin as `--proxy-server` and answers the challenge from `QWebEnginePage::proxyAuthenticationRequired`. Skipping that signal is not a smaller feature, it is a hang: Qt cancels the request and the page says nothing about a password being wanted.

## Verified against real proxies, not documentation

| check | result |
|---|---|
| plain proxy | logging proxy records `CONNECT example.com`, page loads |
| `--proxy-bypass` | `example.com` goes through it, `127.0.0.1` does not appear in the log |
| authenticating proxy | records `CHALLENGE` then `OK`, page returns its real title |
| validation | `ftp://`, `://broken` and empty all exit 1 with a message naming the accepted schemes |

## No per-tab proxy, and the docs say so

`QWebEngineProfile` has no proxy API — zero matches across the QtWebEngineCore headers — because Chromium keeps proxy settings per process. Two proxies means two browsers on two ports, addressed with `--port`. That sentence is in the README, the reference page, `llms.txt` **and both skill documents**, so an agent reading `anoa skills get core` does not reach for `tab new --proxy` and wonder why nothing changed.

## Tests

CFG-25: bad schemes refused, bare host normalised to `http://`, socks5 preserved, credentials preserved, bypass stored, absent stays empty.

Local: integration 118 passed / 21 skipped, unit 4/4, port layout 13/0, smoke 5/0.