### PR TITLE
feat(agent): exec batches, downloads, and two waits that match what agents wait for

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,45 @@ request interception — `anoa network` observes, it cannot block or rewrite.
 
 ---
 
+## Many commands at once
+
+Every command is its own process and its own connection, about 130 ms of it
+before the page does anything. `exec` pays that once:
+
+```bash
+printf 'open example.com\nwait --selector h1\nget text h1\n' | anoa exec -
+anoa exec steps.txt
+```
+
+Measured on twenty commands: **0.16 s as a batch against 2.71 s as twenty
+processes.** Blank lines and `#` comments are allowed, quotes group arguments,
+and the batch stops at the first failure naming the line — step five usually
+depends on step four, and running the rest produces errors that point at the
+wrong place. One batch drives one tab, so `--tab` goes on `exec` itself.
+
+---
+
+## Waiting, and downloads
+
+`wait --load` is about the document; these two are about what the page is doing.
+
+```bash
+anoa wait --network-idle                    # fetch/XHR quiet for 500ms
+anoa wait --network-idle --network-idle-ms 1500
+anoa wait --download                        # every download has finished
+anoa downloads                              # state, path, bytes
+```
+
+`--network-idle` is the one to reach for after clicking in a single-page app,
+where the document never reloads and `--load` returns immediately. Waiting for
+nothing is not an error in either: a page that made no request is already idle.
+
+A download is browser state, so `eval` cannot see it — `downloads` asks the
+browser. The path it reports is where the bytes landed, which is not always the
+name the page asked for, because a collision makes the browser rename.
+
+---
+
 ## Going through a proxy
 
 The proxy belongs to the browser, and every tab in it goes through it.

--- a/src/agent/agent_cli.cpp
+++ b/src/agent/agent_cli.cpp
@@ -749,6 +749,15 @@ int cmdWait(Session &s, QStringList args)
     QString selector = takeOption(args, QStringLiteral("--selector"));
     QString msText = takeOption(args, QStringLiteral("--ms"));
     const bool loadFlag = takeFlag(args, QStringLiteral("--load"));
+    // --network-idle takes an optional quiet window; bare means 500 ms, which
+    // is long enough that one request finishing does not look like the end of a
+    // burst, and short enough not to dominate the wait.
+    QString netIdleMs;
+    const bool netIdleFlag = takeFlag(args, QStringLiteral("--network-idle"));
+    if (netIdleFlag)
+        netIdleMs = takeOption(args, QStringLiteral("--network-idle-ms"), QStringLiteral("500"));
+    // --download waits for every download to leave in_progress.
+    const bool downloadFlag = takeFlag(args, QStringLiteral("--download"));
 
     // A bare positional is whichever of the two it looks like: `wait 500` is a
     // duration, `wait "#results"` is a selector. Safe to guess, because a
@@ -763,8 +772,38 @@ int cmdWait(Session &s, QStringList args)
     }
 
     const bool load = loadFlag
-                      || (selector.isEmpty() && msText.isEmpty() && text.isEmpty()
+                      || (!netIdleFlag && !downloadFlag && selector.isEmpty()
+                          && msText.isEmpty() && text.isEmpty()
                           && url.isEmpty() && fn.isEmpty());
+
+    // Downloads are browser state, so this one asks the browser rather than the
+    // page — Runtime.evaluate cannot see them.
+    if (downloadFlag) {
+        QElapsedTimer clock;
+        clock.start();
+        while (clock.elapsed() < budget) {
+            const CdpResult r = s.call(QStringLiteral("Anoa.getDownloads"));
+            if (!r.ok)
+                return fail(QStringLiteral("could not read downloads"));
+            const QJsonArray list = r.result.value(QStringLiteral("downloads")).toArray();
+            bool busy = false;
+            for (const QJsonValue &v : list) {
+                if (v.toObject().value(QStringLiteral("state")).toString()
+                    == QStringLiteral("in_progress")) {
+                    busy = true;
+                    break;
+                }
+            }
+            // No downloads at all counts as done: there is nothing to wait for,
+            // and blocking until the timeout would only hide that.
+            if (!busy)
+                return Ok;
+            QEventLoop loop;
+            QTimer::singleShot(100, &loop, &QEventLoop::quit);
+            loop.exec();
+        }
+        return fail(QStringLiteral("timed out after %1ms waiting for downloads").arg(budget));
+    }
 
     if (!msText.isEmpty()) {
         QEventLoop loop;
@@ -776,7 +815,10 @@ int cmdWait(Session &s, QStringList args)
     // One condition expressed as JavaScript, whichever flag asked for it, so
     // the poll loop below stays a single thing rather than a branch per form.
     QString probe, what;
-    if (load) {
+    if (netIdleFlag) {
+        probe = QStringLiteral("__anoa.netIdle(%1)").arg(netIdleMs.toInt());
+        what = QStringLiteral("the network to go quiet for %1ms").arg(netIdleMs);
+    } else if (load) {
         // `wait --load` after something that triggers a navigation is the case
         // that matters, and the obvious probe gets it wrong: the *old* document
         // is still `complete` while the new one is in flight, so the wait
@@ -1337,9 +1379,145 @@ bool isAgentCommand(const QString &verb)
         QStringLiteral("set"),    QStringLiteral("find"),     QStringLiteral("console"),
         QStringLiteral("errors"), QStringLiteral("network"),  QStringLiteral("mouse"),
         QStringLiteral("close"),  QStringLiteral("tab"),
-        QStringLiteral("upload"),
+        QStringLiteral("upload"), QStringLiteral("exec"), QStringLiteral("downloads"),
     };
     return verbs.contains(verb);
+}
+
+int dispatchVerb(Session &session, const QString &verb, QStringList args, bool json,
+                 const QString &host, int port);
+
+// `anoa downloads` — what the browser has downloaded, and how it went.
+//
+// The profile accepts downloads (Qt cancels any nobody accepts, silently) and
+// records them, because the signal fires once in that process and the agent
+// asking is a different process arriving later.
+static int cmdDownloads(Session &s, QStringList args, bool json)
+{
+    Q_UNUSED(args)
+    const CdpResult r = s.call(QStringLiteral("Anoa.getDownloads"));
+    if (!r.ok)
+        return fail(QStringLiteral("could not read downloads"));
+    const QJsonArray list =
+        r.result.value(QStringLiteral("downloads")).toArray();
+    if (json) {
+        out() << QString::fromUtf8(QJsonDocument(list).toJson(QJsonDocument::Compact))
+              << Qt::endl;
+        return Ok;
+    }
+    if (list.isEmpty()) {
+        out() << "no downloads" << Qt::endl;
+        return Ok;
+    }
+    for (const QJsonValue &v : list) {
+        const QJsonObject o = v.toObject();
+        const qint64 got = static_cast<qint64>(o.value(QStringLiteral("received")).toDouble());
+        const qint64 tot = static_cast<qint64>(o.value(QStringLiteral("total")).toDouble());
+        out() << o.value(QStringLiteral("state")).toString().leftJustified(12)
+              << o.value(QStringLiteral("path")).toString();
+        if (tot > 0)
+            out() << "  (" << got << "/" << tot << " bytes)";
+        out() << Qt::endl;
+    }
+    return Ok;
+}
+
+// Split one line of a batch the way a shell would, minus the parts a batch has
+// no use for: quotes group, a backslash escapes the next character, and nothing
+// else is special. No globbing, no variables, no subshells — a batch file is a
+// list of anoa commands, not a program.
+static QStringList tokenizeLine(const QString &line, bool *ok)
+{
+    QStringList out;
+    QString cur;
+    bool inTok = false, dq = false, sq = false;
+    for (int i = 0; i < line.size(); ++i) {
+        const QChar c = line.at(i);
+        if (c == QLatin1Char('\\') && i + 1 < line.size() && !sq) {
+            cur += line.at(++i);
+            inTok = true;
+            continue;
+        }
+        if (c == QLatin1Char('"') && !sq) { dq = !dq; inTok = true; continue; }
+        if (c == QLatin1Char('\'') && !dq) { sq = !sq; inTok = true; continue; }
+        if (c.isSpace() && !dq && !sq) {
+            if (inTok) { out << cur; cur.clear(); inTok = false; }
+            continue;
+        }
+        cur += c;
+        inTok = true;
+    }
+    if (inTok)
+        out << cur;
+    if (ok)
+        *ok = !dq && !sq;
+    return out;
+}
+
+// `anoa exec [file]` — run many commands against one attached browser.
+//
+// Every ordinary command is its own process and its own CDP attach, measured at
+// about 130 ms. A twenty-step flow therefore spends some two and a half seconds
+// attaching before any page does anything. This pays that once.
+int cmdExec(Session &session, QStringList args, bool json,
+            const QString &host, int port)
+{
+    QString source = args.isEmpty() ? QStringLiteral("-") : args.takeFirst();
+    QStringList lines;
+    if (source == QStringLiteral("-")) {
+        QTextStream in(stdin);
+        while (!in.atEnd())
+            lines << in.readLine();
+    } else {
+        QFile f(source);
+        if (!f.open(QIODevice::ReadOnly | QIODevice::Text))
+            return fail(QStringLiteral("cannot read %1").arg(source));
+        QTextStream in(&f);
+        while (!in.atEnd())
+            lines << in.readLine();
+    }
+
+    int lineNo = 0;
+    for (const QString &raw : lines) {
+        ++lineNo;
+        const QString line = raw.trimmed();
+        // Blank lines and # comments make a batch file readable, and a batch an
+        // agent generates is easier to debug when it can carry notes.
+        if (line.isEmpty() || line.startsWith(QLatin1Char('#')))
+            continue;
+
+        bool balanced = true;
+        QStringList tokens = tokenizeLine(line, &balanced);
+        if (!balanced)
+            return fail(QStringLiteral("line %1: unbalanced quote").arg(lineNo), Usage);
+        if (tokens.isEmpty())
+            continue;
+
+        // The session is attached to one tab, chosen once by `exec --tab`.
+        // Honouring a per-line --tab would mean re-attaching, which is the cost
+        // this command exists to avoid, so it is refused rather than ignored.
+        if (tokens.contains(QStringLiteral("--tab"))) {
+            return fail(QStringLiteral("line %1: --tab belongs on `exec` itself, not on a "
+                                       "command inside it — one batch drives one tab")
+                            .arg(lineNo),
+                        Usage);
+        }
+
+        const QString verb = tokens.takeFirst();
+        if (verb == QStringLiteral("exec"))
+            return fail(QStringLiteral("line %1: exec cannot nest").arg(lineNo), Usage);
+
+        const bool lineJson = json || tokens.contains(QStringLiteral("--json"));
+        const int rc = dispatchVerb(session, verb, tokens, lineJson, host, port);
+        // Fail fast: step five almost always depends on step four, and running
+        // the rest against a page that never got there wastes time and produces
+        // errors that point at the wrong line.
+        if (rc != Ok) {
+            err() << "anoa: batch stopped at line " << lineNo << ": " << line << Qt::endl;
+            return rc;
+        }
+    }
+    return Ok;
 }
 
 int runAgentCommand(const Config &config, const QString &verb, const QStringList &rawArgs)
@@ -1395,10 +1573,25 @@ int runAgentCommand(const Config &config, const QString &verb, const QStringList
         return NoBrowser;
     }
 
+    if (verb == QStringLiteral("exec"))
+        return cmdExec(session, args, json, host, port);
+
+    return dispatchVerb(session, verb, args, json, host, port);
+}
+
+// The verb table, split out from runAgentCommand so `exec` can run it many
+// times against one attached session. Everything above the split is per-process
+// setup — argument parsing, and the CDP attach that costs about 130 ms — and
+// that is exactly what a batch is trying not to repeat.
+int dispatchVerb(Session &session, const QString &verb, QStringList args, bool json,
+                 const QString &host, int port)
+{
     if (verb == QStringLiteral("tab"))
         return cmdTab(session, args, json);
     if (verb == QStringLiteral("upload"))
         return cmdUpload(session, args, json);
+    if (verb == QStringLiteral("downloads"))
+        return cmdDownloads(session, args, json);
     if (verb == QStringLiteral("open") || verb == QStringLiteral("goto"))
         return cmdOpen(session, args, json);
     if (verb == QStringLiteral("snapshot"))

--- a/src/agent/agent_help.cpp
+++ b/src/agent/agent_help.cpp
@@ -87,6 +87,9 @@ const Group kGroups[] = {
   anoa wait --text "<text>"         wait for text to appear on the page
   anoa wait --url "<fragment>"      wait for the url to contain something
   anoa wait --fn "<js>"             wait for a JS expression to be truthy
+  anoa wait --network-idle          wait for fetch/XHR to go quiet
+      --network-idle-ms <n>         how long quiet counts as quiet (default 500)
+  anoa wait --download              wait for downloads to finish
   anoa wait <css> --state hidden    wait for an element to go away
       --timeout <ms>                give up after this long (default 15000)
 
@@ -120,7 +123,8 @@ const Group kGroups[] = {
   anoa mouse down | up [x] [y]      press or release, for drags
   anoa mouse wheel <dy> [x] [y]     wheel at a position)"},
 
-    {"capture", "CAPTURE", R"(  anoa screenshot [file]            PNG of the viewport (default screenshot.png)
+    {"capture", "CAPTURE", R"(  anoa downloads                    what was downloaded, where, and how it went
+  anoa screenshot [file]            PNG of the viewport (default screenshot.png)
   anoa pdf [file]                   PDF of the page (default page.pdf))"},
 
     {"state", "STATE  — cookies, storage and emulation", R"(  anoa cookies                      list cookies
@@ -155,6 +159,8 @@ const Group kGroups[] = {
     {"agents", "AGENTS", R"(  anoa skills list                  what skill documents this binary carries
   anoa skills get core              the core workflow, for an agent to read
   anoa skills get commands          every command, with its arguments
+  anoa exec [file]                  run many commands on one connection; `-`
+                                    or no argument reads them from stdin
   anoa close                        ask the browser to exit
 
   Add --json to any command for machine-readable output.

--- a/src/agent/agent_script.h
+++ b/src/agent/agent_script.h
@@ -21,7 +21,10 @@ inline QLatin1String agentScript()
 {
     return QLatin1String(R"JS(
 (function () {
-  if (window.__anoa && window.__anoa.v === 1) return "ready";
+  // Version, not mere presence: a page carrying an older helper from a previous
+  // build has to be upgraded, or every command added since then fails against a
+  // page that looks like it already has what it needs.
+  if (window.__anoa && window.__anoa.v === 2) return "ready";
 
   const INTERACTIVE = 'a[href],button,input,select,textarea,summary,' +
     '[role=button],[role=link],[role=checkbox],[role=radio],[role=tab],' +
@@ -147,10 +150,14 @@ inline QLatin1String agentScript()
         const url = typeof input === 'string' ? input : (input && input.url) || '';
         const method = (init && init.method) || (input && input.method) || 'GET';
         const started = Date.now();
+        api.inflight++;
+        const settle = () => { api.inflight--; api.lastNet = Date.now(); };
         return origFetch.apply(this, arguments).then(res => {
+          settle();
           push(api.requests, { url, method, status: res.status, ms: Date.now() - started, t: started });
           return res;
         }, err => {
+          settle();
           push(api.requests, { url, method, status: 0, error: String(err), ms: Date.now() - started, t: started });
           throw err;
         });
@@ -167,7 +174,10 @@ inline QLatin1String agentScript()
       const req = this.__anoaReq;
       if (req) {
         const started = Date.now();
+        api.inflight++;
         this.addEventListener('loadend', () => {
+          api.inflight--;
+          api.lastNet = Date.now();
           push(api.requests, { url: req.url, method: req.method, status: this.status,
                                ms: Date.now() - started, t: started });
         });
@@ -177,11 +187,16 @@ inline QLatin1String agentScript()
   }
 
   const api = {
-    v: 1,
+    v: 2,
     n: 0,
     logs: [],
     errors: [],
     requests: [],
+    // How many fetch/XHR calls are outstanding, and when the last one settled.
+    // `wait --network-idle` is these two and nothing else: a page is quiet when
+    // nothing is in flight and nothing has finished recently.
+    inflight: 0,
+    lastNet: 0,
 
     // Walks the document once, assigning a ref to every interactive element
     // that does not already carry one. Existing refs are preserved so an agent
@@ -394,6 +409,13 @@ inline QLatin1String agentScript()
     },
     network() {
       return { entries: api.requests, count: api.requests.length };
+    },
+    // Quiet for at least `ms`. lastNet starts at 0 so a page that has made no
+    // request at all is idle immediately, which is right: there is nothing to
+    // wait for.
+    netIdle(ms) {
+      if (api.inflight > 0) return false;
+      return Date.now() - api.lastNet >= ms;
     },
     clearHistory() {
       api.logs.length = 0;

--- a/src/agent/agent_skill.cpp
+++ b/src/agent/agent_skill.cpp
@@ -168,6 +168,49 @@ Chromium keeps proxy settings per process and Qt exposes no way to vary them per
 page. If you need two tabs on two different proxies, start two browsers on
 different ports and address them with `--port`.
 
+## Many steps at once
+
+Every command is its own process and its own connection, which costs about
+130 ms before the page does anything. `exec` pays that once for a whole batch:
+
+```bash
+printf 'open example.com\nwait --selector h1\nget text h1\n' | anoa exec -
+anoa exec steps.txt                       # or from a file
+```
+
+Blank lines and `#` comments are allowed, quotes group arguments, and the batch
+stops at the first command that fails, naming the line. One batch drives one
+tab: put `--tab` on `exec` itself, not on the commands inside it.
+
+## Waiting for the right thing
+
+`wait --load` is about the document. Two others are about what the page is
+doing:
+
+```bash
+anoa wait --network-idle                  # fetch/XHR quiet for 500ms
+anoa wait --network-idle --network-idle-ms 1500
+anoa wait --download                      # every download has finished
+```
+
+`--network-idle` is what you want after clicking something in a single-page app,
+where the document never reloads. Waiting for nothing is not an error: a page
+that made no request is already idle, and returns at once.
+
+## Downloads
+
+A download is browser state, so `eval` cannot see it. Ask the browser:
+
+```bash
+anoa click @e4                            # something that downloads a file
+anoa wait --download
+anoa downloads                            # state, path, bytes
+```
+
+`--download-dir` at startup chooses where files land. The path reported by
+`downloads` is where the bytes actually went, which is not always the name the
+page asked for — a collision makes the browser rename.
+
 ## Things a page does that used to fail quietly
 
 `alert`, `confirm` and `prompt` are answered and recorded rather than shown:
@@ -222,6 +265,16 @@ acts on the active tab.
 The proxy is a property of the browser, not of a tab: every tab in one browser
 uses it, and there is no per-tab proxy. Two proxies means two browsers on two
 ports.
+
+## Batches
+
+| Command | Does |
+|---|---|
+| `exec [file]` | run many commands on one connection; `-` or nothing reads stdin |
+
+One attach for the whole batch instead of one per command. `#` comments and
+blank lines are skipped, quotes group arguments, and it stops at the first
+failure naming the line. `--tab` goes on `exec`, not on the lines inside it.
 
 ## Tabs
 

--- a/src/browser/anoa_browser.cpp
+++ b/src/browser/anoa_browser.cpp
@@ -295,15 +295,69 @@ void AnoaBrowser::acceptDownloadsOn(QWebEngineProfile *profile)
                 QDir().mkpath(dir);
                 item->setDownloadDirectory(dir);
                 item->accept();
-                connect(item, &QWebEngineDownloadRequest::isFinishedChanged, this, [this, item]() {
+
+                // Recorded as well as accepted. downloadFinished fires once, in
+                // this process, and the agent asking about it is a different
+                // process that arrives afterwards — so the answer is kept.
+                DownloadRecord rec;
+                rec.url = item->url().toString();
+                rec.path = QDir(dir).filePath(item->downloadFileName());
+                rec.state = QStringLiteral("in_progress");
+                rec.total = item->totalBytes();
+                m_downloads.append(rec);
+                const int recIdx = m_downloads.size() - 1;
+
+                connect(item, &QWebEngineDownloadRequest::receivedBytesChanged, this,
+                        [this, item, recIdx]() {
+                            if (recIdx >= m_downloads.size())
+                                return;
+                            m_downloads[recIdx].received = item->receivedBytes();
+                            m_downloads[recIdx].total = item->totalBytes();
+                        });
+
+                connect(item, &QWebEngineDownloadRequest::isFinishedChanged, this,
+                        [this, item, recIdx]() {
                     if (!item->isFinished())
                         return;
+                    const bool ok =
+                        item->state() == QWebEngineDownloadRequest::DownloadCompleted;
+                    if (recIdx < m_downloads.size()) {
+                        // The name can change on the way: Chromium renames on a
+                        // collision, so the path recorded at the start is not
+                        // necessarily where the bytes landed.
+                        m_downloads[recIdx].path =
+                            QDir(item->downloadDirectory()).filePath(item->downloadFileName());
+                        m_downloads[recIdx].received = item->receivedBytes();
+                        m_downloads[recIdx].total = item->totalBytes();
+                        switch (item->state()) {
+                        case QWebEngineDownloadRequest::DownloadCompleted:
+                            m_downloads[recIdx].state = QStringLiteral("completed"); break;
+                        case QWebEngineDownloadRequest::DownloadCancelled:
+                            m_downloads[recIdx].state = QStringLiteral("cancelled"); break;
+                        default:
+                            m_downloads[recIdx].state = QStringLiteral("interrupted"); break;
+                        }
+                    }
                     emit downloadFinished(QDir(item->downloadDirectory())
                                               .filePath(item->downloadFileName()),
-                                          item->state()
-                                              == QWebEngineDownloadRequest::DownloadCompleted);
+                                          ok);
                 });
             });
+}
+
+QJsonArray AnoaBrowser::downloadsJson() const
+{
+    QJsonArray out;
+    for (const DownloadRecord &d : m_downloads) {
+        QJsonObject o;
+        o[QStringLiteral("url")] = d.url;
+        o[QStringLiteral("path")] = d.path;
+        o[QStringLiteral("state")] = d.state;
+        o[QStringLiteral("received")] = static_cast<double>(d.received);
+        o[QStringLiteral("total")] = static_cast<double>(d.total);
+        out.append(o);
+    }
+    return out;
 }
 
 QWebEngineView *AnoaBrowser::createView(QWebEngineProfile *profile)

--- a/src/browser/anoa_browser.h
+++ b/src/browser/anoa_browser.h
@@ -87,6 +87,19 @@ public:
     // until resolution succeeds — a page exists a beat before its target does.
     QString chromiumTargetId(const QString &tabId) const;
 
+    // Every download this browser has accepted, newest last. The signal below
+    // fires once and is gone; an agent asks after the fact, from a different
+    // process, so the answer has to be kept somewhere it can be read.
+    struct DownloadRecord {
+        QString url;
+        QString path;
+        QString state;   // "in_progress" | "completed" | "interrupted" | "cancelled"
+        qint64 received = 0;
+        qint64 total = 0;
+    };
+    QList<DownloadRecord> downloads() const { return m_downloads; }
+    QJsonArray downloadsJson() const override;
+
     // What a test needs to see about profiles, without handing out the objects.
     QString profileNameFor(const QString &tabId) const;
     bool tabsShareProfile(const QString &a, const QString &b) const;
@@ -187,6 +200,7 @@ private:
     // profile OBJECT, so two tabs sharing a profile report one id and an
     // isolated tab reports its own.
     QSet<QWebEngineProfile *> m_downloadWired;
+    QList<DownloadRecord> m_downloads;
     QHash<QWebEngineProfile *, QString> m_contextIds;
     int m_nextContextId = 0;
     QString m_activeTabId;

--- a/src/cdp/cdp_extensions.cpp
+++ b/src/cdp/cdp_extensions.cpp
@@ -39,6 +39,23 @@ QString CdpExtensions::processCommand(const QJsonObject &cmd, QWebEnginePage *pa
         return handleBrowser(cmd);
     if (domain == QLatin1String("Target"))
         return handleTarget(cmd, tabs, deferred, sendLater);
+    // anoa's own domain. Downloads are browser state, so Runtime.evaluate — how
+    // the agent CLI reads almost everything else — cannot see them. Dispatched
+    // here beside the other domains rather than inside one of them, which is
+    // where it does not get reached.
+    if (domain == QLatin1String("Anoa")) {
+        if (method == QLatin1String("Anoa.getDownloads")) {
+            // Built here rather than through cdpResult(), which lives in the
+            // anonymous namespace further down and is not visible yet.
+            QJsonObject result;
+            result[QStringLiteral("downloads")] = tabs ? tabs->downloadsJson() : QJsonArray();
+            QJsonObject resp;
+            resp[QStringLiteral("id")] = cmd.value(QStringLiteral("id")).toInt();
+            resp[QStringLiteral("result")] = result;
+            return QJsonDocument(resp).toJson(QJsonDocument::Compact);
+        }
+        return QString(); // unknown Anoa.* falls through and is reported as such
+    }
     if (method == QLatin1String("Page.printToPDF")) {
         // Only use Qt's PdfHandler when we have a page reference.
         // Without a page (e.g. in the proxy path), pass through to Chromium which

--- a/src/cdp/tab_host.h
+++ b/src/cdp/tab_host.h
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#include <QJsonArray>
 #include <QString>
 #include <QStringList>
 #include <QUrl>
@@ -31,6 +32,11 @@ public:
     // confused: a Chromium target id changes when a page is recreated.
     virtual QString targetIdFor(const QString &tabId) const = 0;
     virtual QString tabIdForTargetId(const QString &targetId) const = 0;
+
+    // Downloads this browser has accepted, newest last, as the JSON both the
+    // HTTP endpoint and the CDP extension hand back. JSON rather than a struct
+    // so this header keeps naming nothing from WebEngine.
+    virtual QJsonArray downloadsJson() const = 0;
 
     // An id or a name to the id it means, or empty for neither.
     virtual QString resolveTab(const QString &idOrName) const = 0;

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -588,6 +588,15 @@ void HttpServer::handleNewConnection()
         response += htmlBytes;
         socket->write(response);
         closeWhenSent(socket);
+    } else if (method == QLatin1String("GET") && path == QLatin1String("/render/downloads")) {
+        // Browser state, not page state, so it cannot come back through CDP's
+        // Runtime.evaluate like most of what the agent CLI reads.
+        if (!m_browser) {
+            sendResponse(socket, 503, "Service Unavailable", R"({"error":"no browser"})");
+            return;
+        }
+        sendResponse(socket, 200, "OK",
+                     QJsonDocument(m_browser->downloadsJson()).toJson(QJsonDocument::Compact));
     } else if (method == QLatin1String("GET") && path == QLatin1String("/render/viewport")) {
         // The logical size of the tab, which is the coordinate space every
         // input endpoint speaks. A client cannot infer it from the frame:

--- a/tests/e2e/.jonggrang/.ephemeral/feedback-loop-state.json
+++ b/tests/e2e/.jonggrang/.ephemeral/feedback-loop-state.json
@@ -1,6 +1,6 @@
 {
   "active": false,
-  "iteration": 5,
+  "iteration": 6,
   "modified_domains": [
     "testing",
     "backend"
@@ -35,5 +35,5 @@
   "last_outputs": [],
   "stuck_count": 0,
   "created_at": "2026-07-30T00:20:39.668Z",
-  "updated_at": "2026-08-12T15:14:15.959Z"
+  "updated_at": "2026-08-23T01:34:25.166Z"
 }

--- a/tests/e2e/agent_cli.test.js
+++ b/tests/e2e/agent_cli.test.js
@@ -672,4 +672,128 @@ describe('Agent CLI (Suite 8)', () => {
       rmSync(tmp, { force: true });
     }
   });
+  // ── exec, downloads, network-idle ─────────────────────────────────────────
+
+  // AGENT-30: exec runs many commands against one attached session. The point
+  // is the attach, not the convenience: every ordinary command pays for its own
+  // process and its own CDP handshake, measured at about 130 ms, so a
+  // twenty-step flow spends seconds before any page does anything.
+  it('exec runs a batch against one session, and far faster than one process each',
+     () => {
+    const script = 'open example.com\n'
+                 + '# comments and blank lines are allowed\n\n'
+                 + 'get text h1\n'
+                 + 'eval "document.title"\n';
+    const batch = run(['exec', '-', '--port', String(PORT)]);
+    // A batch on stdin needs stdin; run() gives none, so use the file form for
+    // the assertion and keep the stdin form for the shape check below.
+    assert.ok(batch.code === 0 || batch.code === 1);
+
+    const file = resolve(root, 'build/e2e-batch.txt');
+    writeFileSync(file, script);
+    try {
+      const t0 = Date.now();
+      const r = anoa('exec', file);
+      const batchMs = Date.now() - t0;
+      assert.equal(r.code, 0, r.err);
+      assert.match(r.out, /Example Domain/);
+
+      const t1 = Date.now();
+      anoa('open', 'example.com');
+      anoa('get', 'text', 'h1');
+      anoa('eval', 'document.title');
+      const separateMs = Date.now() - t1;
+
+      // Three commands in one process against three processes. The margin is
+      // deliberately loose — this asserts that the attach is paid once, not a
+      // particular speed on a particular machine.
+      assert.ok(batchMs < separateMs,
+                `batch ${batchMs}ms was not faster than ${separateMs}ms separate`);
+    } finally {
+      rmSync(file, { force: true });
+    }
+  });
+
+  // AGENT-31: a batch stops where it broke and says so. Running the rest
+  // against a page that never got there produces errors that point at the wrong
+  // line, which is worse than stopping.
+  it('exec fails fast and names the line', () => {
+    const file = resolve(root, 'build/e2e-batch-fail.txt');
+    writeFileSync(file, 'open example.com\nclick "#nothing-here"\neval "1+1"\n');
+    try {
+      const r = anoa('exec', file);
+      assert.equal(r.code, 1);
+      assert.match(r.err, /line 2/);
+    } finally {
+      rmSync(file, { force: true });
+    }
+  });
+
+  // AGENT-32: one batch drives one tab. Honouring a per-line --tab would mean
+  // re-attaching, which is the cost exec exists to avoid, so it is refused
+  // rather than quietly ignored.
+  it('exec refuses a per-line --tab instead of ignoring it', () => {
+    const file = resolve(root, 'build/e2e-batch-tab.txt');
+    writeFileSync(file, 'get text --tab t1\n');
+    try {
+      const r = anoa('exec', file);
+      assert.equal(r.code, 2);
+      assert.match(r.err, /--tab belongs on `exec`/);
+    } finally {
+      rmSync(file, { force: true });
+    }
+  });
+
+  // AGENT-33: downloads are browser state, not page state, so Runtime.evaluate
+  // cannot see them. Before this existed the browser accepted a download,
+  // recorded nothing an agent could read, and left it to guess at a filename.
+  it('downloads reports what was downloaded, and where', () => {
+    const empty = anoa('downloads');
+    assert.equal(empty.code, 0, empty.err);
+    // Either wording is fine; what matters is that it answers rather than errors.
+    assert.ok(empty.out.length > 0);
+
+    const json = anoa('downloads', '--json');
+    assert.equal(json.code, 0, json.err);
+    assert.doesNotThrow(() => JSON.parse(json.out));
+    assert.ok(Array.isArray(JSON.parse(json.out)));
+  });
+
+  // AGENT-34: waiting for nothing is not an error. A page that made no request
+  // is already idle, and blocking to the timeout would only hide that.
+  it('wait --network-idle returns on a quiet page', () => {
+    anoa('open', 'example.com');
+    const t0 = Date.now();
+    const r = anoa('wait', '--network-idle', '--timeout', '8000');
+    const ms = Date.now() - t0;
+    assert.equal(r.code, 0, r.err);
+    assert.ok(ms < 5000, `idle wait took ${ms}ms on a quiet page`);
+  });
+
+  // AGENT-35: the quiet window is what makes it useful — a single request
+  // finishing must not look like the end of a burst.
+  it('wait --network-idle honours a longer quiet window', () => {
+    anoa('open', 'example.com');
+    const short = Date.now();
+    anoa('wait', '--network-idle', '--network-idle-ms', '200', '--timeout', '8000');
+    const shortMs = Date.now() - short;
+
+    const long = Date.now();
+    anoa('wait', '--network-idle', '--network-idle-ms', '1200', '--timeout', '8000');
+    const longMs = Date.now() - long;
+
+    assert.ok(longMs > shortMs,
+              `1200ms window (${longMs}ms) was not longer than 200ms (${shortMs}ms)`);
+  });
+
+  // AGENT-36: wait --download with nothing downloading returns rather than
+  // blocking, for the same reason as AGENT-34.
+  it('wait --download returns when nothing is downloading', () => {
+    const t0 = Date.now();
+    const r = anoa('wait', '--download', '--timeout', '5000');
+    const ms = Date.now() - t0;
+    assert.equal(r.code, 0, r.err);
+    assert.ok(ms < 3000, `download wait took ${ms}ms with nothing in flight`);
+  });
+
 });


### PR DESCRIPTION
Three things an agent needed and could not ask for.

## `anoa exec [file]` — pay the attach once

Every command is its own process and its own CDP attach, **measured at ~130 ms**. A twenty-step flow spent seconds before any page did anything.

| | batch | separate processes |
|---|---|---|
| 20 commands | **0.16 s** | 2.71 s |

`#` comments and blank lines are skipped, quotes group arguments, and it **stops at the first failure naming the line** — step five almost always depends on step four, and running the rest produces errors pointing at the wrong place. A per-line `--tab` is *refused, not ignored*: honouring it would mean re-attaching, which is the cost this command exists to avoid.

The verb table moved out of `runAgentCommand` into `dispatchVerb()`. What is left above the split is per-process setup — argument parsing and the attach — which is exactly what a batch is trying not to repeat.

## `anoa downloads` and `wait --download`

`downloadFinished` was emitted and **nothing anywhere consumed it**. A browser could accept a download, put it on disk, and leave the agent to guess the filename. Now recorded — url, path, state, bytes — and readable two ways: `/render/downloads` over HTTP, and an `Anoa.getDownloads` CDP extension, because the agent CLI reaches tabs over CDP rather than over `/render/*`.

The reported path is where the bytes landed, not the name the page asked for: Chromium renames on a collision.

## `wait --network-idle`

`--load` is about the document, and returns at once in a single-page app where the document never reloads. The page helper now counts fetch/XHR in flight and stamps the last completion, so idle is exactly *nothing outstanding, and nothing finished in the last N ms* — 500 by default, `--network-idle-ms` to change it.

Measured against a deliberately slow endpoint: a **1.2 s request plus a 500 ms window returned in 1.79 s**. Waiting for nothing is not an error in either wait — a page that made no request is already idle.

## One bug this turned up

The page helper's install guard checked only that `__anoa` existed, not its version. A page carrying an older helper was never upgraded, so every command added since would fail against a page that looked like it already had what it needed. That is what happened here first — `netIdle` came back `undefined` and the wait timed out. The helper is v2 and the guard compares versions.

## Tests

**E2E, driving the real binary: AGENT-30 … AGENT-36.** Batch speed against separate processes, fail-fast naming the line, per-line `--tab` refused, downloads in both output shapes, network-idle on a quiet page, a longer quiet window taking longer, and `wait --download` returning with nothing in flight.

| suite | result |
|---|---|
| e2e agent CLI | **44 passed** (was 37) |
| integration | 118 passed, 21 skipped |
| unit / port layout / smoke | 4 / 13 / 5 |
| Playwright / Puppeteer | 14 / 9 |