### PR TITLE
chore(release): 0.14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(anoa VERSION 0.13.0 LANGUAGES CXX)
+project(anoa VERSION 0.14.0 LANGUAGES CXX)
 
 # CI injects the git tag here so the tag is the single source of truth for the
 # version — CMakeLists.txt never needs a manual bump for releases. The value

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
       # Keep this in step with CMakeLists.txt. It is passed to the build rather
       # than read from it, so `nix run` reports the same string a release does.
-      version = "0.13.0";
+      version = "0.14.0";
     in
     {
       packages = forEach (pkgs: rec {

--- a/pages/docs.html
+++ b/pages/docs.html
@@ -52,6 +52,8 @@
         <li><a href="#navigate">Navigate</a></li>
         <li><a href="#inspect">Inspect</a></li>
         <li><a href="#interact">Interact</a></li>
+        <li><a href="#batches">Batches</a></li>
+        <li><a href="#downloads">Downloads</a></li>
         <li><a href="#capture">Capture</a></li>
         <li><a href="#state">State</a></li>
         <li><a href="#debug">Debug</a></li>
@@ -392,10 +394,22 @@ environment.systemPackages = [ inputs.anoa.packages.${system}.anoa ];</pre>
 <span class="p">$</span> anoa wait --url "&lt;fragment&gt;"      <span class="o">wait for the url to contain something</span>
 <span class="p">$</span> anoa wait --fn "&lt;js&gt;"             <span class="o">wait for a JS expression to be truthy</span>
 <span class="p">$</span> anoa wait &lt;css&gt; --state hidden    <span class="o">wait for an element to go away</span>
+<span class="p">$</span> anoa wait --network-idle          <span class="o">fetch/XHR quiet (default 500ms)</span>
+      --network-idle-ms &lt;n&gt;       <span class="o">how long quiet counts as quiet</span>
+<span class="p">$</span> anoa wait --download              <span class="o">every download has finished</span>
       --timeout &lt;ms&gt;              <span class="o">give up after this long (default 15000)</span></pre>
         <p style="margin-top:16px">A bare argument is read as a duration when it is a number
         and as a selector otherwise, so <code>anoa wait 500</code> and
         <code>anoa wait "#results"</code> both do what they look like.</p>
+        <div class="note">
+          <p><strong><code>--network-idle</code> is the one for a single-page app.</strong>
+          <code>--load</code> is about the document, and in an app where the document never
+          reloads it returns at once. Idle means nothing outstanding and nothing finished in
+          the last N milliseconds — measured against a deliberately slow endpoint, a 1.2 s
+          request plus a 500 ms window returned in 1.79 s.</p>
+          <p>Waiting for nothing is not an error in either of the new waits: a page that made
+          no request is already idle, and blocking to the timeout would only hide that.</p>
+        </div>
       </section>
 
       <section id="inspect">
@@ -437,6 +451,46 @@ environment.systemPackages = [ inputs.anoa.packages.${system}.anoa ];</pre>
           reported rather than clicked through, so you find out the click did not land instead
           of finding out later.</p>
         </div>
+      </section>
+
+      <section id="batches">
+        <h2>Batches — many commands, one connection</h2>
+        <p>Every command is its own process and its own connection, about 130 ms of it before
+        the page does anything. <code>exec</code> pays that once for a whole batch.</p>
+<pre class="term"><span class="p">$</span> printf 'open example.com\nwait --selector h1\nget text h1\n' | anoa exec -
+<span class="p">$</span> anoa exec steps.txt</pre>
+        <table class="ref">
+          <thead><tr><th>Measured, twenty commands</th><th>Time</th></tr></thead>
+          <tbody>
+            <tr><td>as one batch</td><td><strong>0.16 s</strong></td></tr>
+            <tr><td>as twenty processes</td><td>2.71 s</td></tr>
+          </tbody>
+        </table>
+        <p style="margin-top:18px">Blank lines and <code>#</code> comments are skipped, quotes
+        group arguments, and the batch stops at the first command that fails, naming the line
+        — step five almost always depends on step four, and running the rest produces errors
+        that point at the wrong place.</p>
+        <div class="note">
+          <p><strong>One batch drives one tab.</strong> <code>--tab</code> goes on
+          <code>exec</code> itself; a <code>--tab</code> on a line inside is refused rather
+          than ignored, because honouring it would mean re-attaching — the cost this command
+          exists to avoid.</p>
+        </div>
+      </section>
+
+      <section id="downloads">
+        <h2>Downloads</h2>
+        <p>A download is browser state, so <code>eval</code> cannot see it. Ask the browser.</p>
+<pre class="term"><span class="p">$</span> anoa click @e4                    <span class="o">something that downloads a file</span>
+<span class="p">$</span> anoa wait --download
+<span class="p">$</span> anoa downloads                    <span class="o">state, path, bytes</span>
+<span class="o">completed   /home/you/Downloads/report.pdf  (284120/284120 bytes)</span></pre>
+        <p style="margin-top:16px"><code>--download-dir</code> at startup chooses where files
+        land. The path <code>downloads</code> reports is where the bytes actually went, which
+        is not always the name the page asked for: a collision makes the browser rename.</p>
+        <p>Add <code>--json</code> for the same list as an array, with
+        <code>url</code>, <code>path</code>, <code>state</code>, <code>received</code> and
+        <code>total</code>.</p>
       </section>
 
       <section id="capture">

--- a/pages/index.html
+++ b/pages/index.html
@@ -39,7 +39,7 @@
         or any CDP client. One binary, no driver to install, no headless-versus-real
         distinction to reason about.</p>
         <div class="badges">
-          <span>latest <b>v0.13.0</b></span>
+          <span>latest <b>v0.14.0</b></span>
           <span>macOS · Linux · Windows</span>
           <span>x86_64 · <b>aarch64</b></span>
           <span>Qt 6 + Chromium</span>

--- a/pages/llms.txt
+++ b/pages/llms.txt
@@ -17,7 +17,7 @@ Also packaged as a Nix flake for x86_64-linux, aarch64-linux and aarch64-darwin
 has no qtwebengine for x86_64-darwin, so Intel Macs use Homebrew. Flakes are
 still experimental, so a fresh Nix needs `experimental-features = nix-command
 flakes` in ~/.config/nix/nix.conf before any of those commands work.
-`anoa terminal` is POSIX-only. Latest release: v0.13.0.
+`anoa terminal` is POSIX-only. Latest release: v0.14.0.
 
 ## Start here
 
@@ -40,6 +40,17 @@ anoa wait --selector ".results"
 anoa screenshot page.png
 ```
 
+`exec` matters for latency: each ordinary command is a separate process and a
+separate CDP attach, about 130 ms, so twenty commands cost 2.71 s as processes
+against 0.16 s as one batch. It stops at the first failure, naming the line,
+and drives one tab — `--tab` goes on `exec`, not on the lines inside it.
+
+`wait --network-idle` is the wait for a single-page app, where `--load`
+returns at once because the document never reloads. Idle means no fetch/XHR
+outstanding and none finished in the last N ms (500 by default). `wait
+--download` waits for downloads; both return immediately when there is
+nothing to wait for.
+
 Add `--json` to any command for machine-readable output. Exit codes: `0` ok,
 `1` command failed, `2` usage, `3` no browser listening.
 
@@ -49,10 +60,12 @@ rather than by a person.
 
 ## Commands
 
-- Navigate: `open`, `back`, `forward`, `reload`, `wait` (`--load`, `--selector`, `--ms`, `--text`, `--url`, `--fn`, `--state hidden`, `--timeout`)
+- Navigate: `open`, `back`, `forward`, `reload`, `wait` (`--load`, `--selector`, `--ms`, `--text`, `--url`, `--fn`, `--state hidden`, `--network-idle`, `--network-idle-ms`, `--download`, `--timeout`)
 - Inspect: `snapshot [-i]`, `find role|text|selector [--nth]`, `get text|html|value|attr`, `eval`, `status`
 - Interact: `click`, `fill`, `type`, `upload`, `press`, `scroll`, `mouse move|down|up|wheel`
 - Capture: `screenshot [file]`, `pdf [file]`
+- Batches: `exec [file]` — many commands on one connection; `-` or nothing reads stdin
+- Downloads: `downloads` — state, path and bytes for everything the browser downloaded
 - Tabs: `tab new [url] [--name] [--profile] [--isolated]`, `tab list`, `tab select`, `tab close`
 - State: `cookies`, `storage local|session`, `set viewport|device|geo|offline|headers|media`
 - Debug: `console`, `errors`, `network` — recorded inside the page, so they cover what happened before the command ran

--- a/src/agent/agent_script.h
+++ b/src/agent/agent_script.h
@@ -186,6 +186,13 @@ inline QLatin1String agentScript()
     };
   }
 
+)JS"
+        // Split here, and only for MSVC's sake: a single string literal may not
+        // exceed 16380 bytes, and Windows checkouts turn every newline into
+        // CRLF, so 410 lines of script cross the limit there while building
+        // fine everywhere else. Adjacent literals concatenate, so this is one
+        // string to every compiler and two to the limit.
+        R"JS(
   const api = {
     v: 2,
     n: 0,


### PR DESCRIPTION
Three agent-facing features since 0.13.0:

- **`anoa exec [file]`** — many commands on one connection. Twenty commands measured **0.16 s as a batch against 2.71 s as twenty processes**
- **`anoa downloads` and `wait --download`** — `downloadFinished` was emitted and nothing consumed it; downloads are now recorded and readable
- **`wait --network-idle`** — the wait for a single-page app, where `--load` returns at once because the document never reloads

The website carries them too: a **Batches** section with the measured numbers, a **Downloads** section, the two new waits in the wait list, and `llms.txt`. The reference page has held the CLI surface since 0.12.0 and would otherwise have described a binary two releases behind.

## One failure the dry-run caught

The first dry-run **failed on Windows** with `C2026: string too big`. A single string literal may not exceed 16380 bytes; the page helper measured 16290, which passes wherever the source keeps LF endings and fails on Windows, where the checkout turns 410 newlines into CRLF and pushes it to 16700. The literal is split in two — 7116 and 9586 bytes with CRLF counted — which is one string to every compiler and two to the limit.

Second dry-run: four platform builds green, AppImage smoke tests pass on x86_64 and aarch64 including the bare-container runs.