### PR TITLE
fix(gui): the tab strip was a zero-height line, and had no way in

### DIFF
--- a/resources/viewer/viewer.html
+++ b/resources/viewer/viewer.html
@@ -102,7 +102,26 @@ body.embed #chrome{display:none}
   }
 
   function post(path, extra) {
-    return fetch(path + "?" + qs(extra), { method: "POST" }).catch(function () {});
+    return fetch(path + "?" + qs(extra), { method: "POST" }).then(function (r) {
+      // Swallowing this is what made a rejected address look like a dead
+      // button: the request 400'd, the catch below ate it, and the page simply
+      // did not move with nothing anywhere to say why.
+      if (!r.ok) flash(r.status === 400 ? "that address was refused" : "request failed");
+      return r;
+    }).catch(function () { flash("could not reach the browser"); });
+  }
+
+  // A short message over the view. The viewer has no console anyone is reading,
+  // and an agent-driven browser is often watched by someone who cannot open one.
+  var flashTimer = 0;
+  function flash(msg) {
+    hint.textContent = msg;
+    hint.classList.add("show");
+    clearTimeout(flashTimer);
+    flashTimer = setTimeout(function () {
+      hint.textContent = "click to give this view the keyboard";
+      if (document.activeElement === stage) hint.classList.remove("show");
+    }, 2500);
   }
 
   // ── the frame ────────────────────────────────────────────────────────────
@@ -347,12 +366,32 @@ body.embed #chrome{display:none}
   });
 
   // ── navigation ───────────────────────────────────────────────────────────
+  // What a person types has no scheme, and /render/navigate is strict on
+  // purpose — a client that posts "relative/path" deserves a 400 rather than a
+  // trip to a host that does not exist. So the rule lives here, at the address
+  // bar, which is the same place the terminal viewer and the desktop window
+  // each apply it. Without it, typing "example.org" 400'd and the page simply
+  // did not move.
+  //
+  // A scheme is letters, digits, +, - and . before a colon, and longer than one
+  // character; a digit straight after the colon is a port, so "localhost:8080"
+  // is a host and not a scheme.
+  function withScheme(typed) {
+    var colon = typed.indexOf(":");
+    if (colon > 1) {
+      var schemeLike = /^[A-Za-z0-9+.-]+$/.test(typed.slice(0, colon));
+      var portLike = /^[0-9]/.test(typed.slice(colon + 1));
+      if (schemeLike && !portLike) return typed;
+    }
+    return "https://" + typed;
+  }
+
   urlEl.addEventListener("keydown", function (ev) {
     if (ev.key !== "Enter") return;
     ev.stopPropagation();
     var v = urlEl.value.trim();
     if (!v) return;
-    post("/render/navigate", { url: v }).then(pollTabs);
+    post("/render/navigate", { url: withScheme(v) }).then(pollTabs);
   });
 
   document.getElementById("back").addEventListener("click", function () {

--- a/src/browser/browser_window.cpp
+++ b/src/browser/browser_window.cpp
@@ -58,23 +58,49 @@ QWidget#anoaTabStrip {
     background: #E2E2E2;
     border-bottom: 1px solid #D0D0D0;
 }
-QToolButton#anoaTab {
+/* One tab is one widget carrying the background, with the label and the close
+   inside it. They used to be two siblings in a flat row: the close was
+   transparent, so on the active tab the label lit up and the x beside it did
+   not, and their paddings differed enough that the accessibility tree reported
+   108x21 next to 39x15 — a shorter, misaligned x floating between tabs rather
+   than belonging to one. */
+QWidget#anoaTab {
     background: #D8D8D8;
     border-right: 1px solid #C8C8C8;
+}
+QWidget#anoaTab[active="true"] { background: #F6F6F6; }
+
+QToolButton#anoaTabLabel {
+    background: transparent;
+    border: none;
     color: #4A4A4A;
-    padding: 3px 8px;
+    padding: 4px 4px 4px 10px;
+    text-align: left;
 }
-QToolButton#anoaTab[active="true"] {
-    background: #F6F6F6;
-    color: #101010;
+QWidget#anoaTab[active="true"] QToolButton#anoaTabLabel { color: #101010; }
+
+/* Narrow, full height, and quiet until you are on it. 39px of x was most of the
+   reason it read as its own button. */
+QToolButton#anoaTabClose {
+    background: transparent;
+    border: none;
+    border-radius: 3px;
+    color: #9A9A9A;
+    padding: 0;
+    margin: 4px 6px 4px 2px;
+    min-width: 16px;
+    max-width: 16px;
 }
-QToolButton#anoaTabClose, QToolButton#anoaTabNew {
+QToolButton#anoaTabClose:hover { background: #C0C0C0; color: #101010; }
+QWidget#anoaTab[active="true"] QToolButton#anoaTabClose:hover { background: #DADADA; }
+
+QToolButton#anoaTabNew {
     background: transparent;
     border: none;
     color: #7A7A7A;
-    padding: 0 6px;
+    padding: 0 10px;
 }
-QToolButton#anoaTabClose:hover, QToolButton#anoaTabNew:hover { color: #101010; }
+QToolButton#anoaTabNew:hover { color: #101010; }
 )";
 
 } // namespace
@@ -300,8 +326,17 @@ void BrowserWindow::rebuildTabStrip()
     const QString active = m_view->activeTabId();
 
     for (const QString &id : ids) {
-        auto *button = new QToolButton(m_tabStrip);
-        button->setObjectName(QStringLiteral("anoaTab"));
+        // The tab is the container; the label and the close live inside it, so
+        // the active background covers both and they read as one thing.
+        auto *tab = new QWidget(m_tabStrip);
+        tab->setObjectName(QStringLiteral("anoaTab"));
+        tab->setProperty("active", id == active);
+        auto *tabLayout = new QHBoxLayout(tab);
+        tabLayout->setContentsMargins(0, 0, 0, 0);
+        tabLayout->setSpacing(0);
+
+        auto *button = new QToolButton(tab);
+        button->setObjectName(QStringLiteral("anoaTabLabel"));
         QString label = m_view->titleFor(id);
         if (label.isEmpty())
             label = m_view->urlFor(id);
@@ -311,21 +346,26 @@ void BrowserWindow::rebuildTabStrip()
             label = label.left(23) + QStringLiteral("\xE2\x80\xA6"); // HORIZONTAL ELLIPSIS
         button->setText(label);
         button->setToolTip(id + QStringLiteral("  ") + m_view->urlFor(id));
-        button->setProperty("active", id == active);
         button->setCursor(Qt::ArrowCursor);
         connect(button, &QToolButton::clicked, this, [this, id]() { m_view->selectTab(id); });
-        m_tabStripLayout->addWidget(button);
+        tabLayout->addWidget(button);
+        m_tabStripLayout->addWidget(tab);
 
         // No close button on the last tab: the registry would refuse it, and
         // offering a control that cannot work is worse than not offering it.
         if (ids.size() > 1) {
-            auto *close = new QToolButton(m_tabStrip);
+            auto *close = new QToolButton(tab);
             close->setObjectName(QStringLiteral("anoaTabClose"));
             close->setText(QStringLiteral("\xC3\x97")); // MULTIPLICATION SIGN
             close->setToolTip(QStringLiteral("Close ") + id);
             close->setCursor(Qt::ArrowCursor);
+            // accessibleName as well as the tooltip: without it every close
+            // button reports as its neighbour, which makes the strip impossible
+            // to check from the outside and a screen reader announce the wrong
+            // tab.
+            close->setAccessibleName(QStringLiteral("Close ") + id);
             connect(close, &QToolButton::clicked, this, [this, id]() { m_view->closeTab(id); });
-            m_tabStripLayout->addWidget(close);
+            tabLayout->addWidget(close);
         }
     }
 

--- a/src/browser/browser_window.cpp
+++ b/src/browser/browser_window.cpp
@@ -249,7 +249,16 @@ void BrowserWindow::layoutToolbar()
 
     // The strip sits under the toolbar and shares its fate: both overlay the
     // page when auto-hide is on, and both are reserved for when it is off.
-    const bool stripVisible = m_tabStrip && m_tabStrip->isVisible();
+    // isHidden(), not isVisible(). isVisible() is false until the show event
+    // has actually been delivered, and rebuildTabStrip() calls setVisible()
+    // and then this function in the same turn — so the strip was measured
+    // before it counted as visible and laid out at zero height. Every tab
+    // button then inherited that: reported by the accessibility layer as
+    // 108x0, 170x0, 85x0. Present, addressable, and impossible to click.
+    //
+    // isHidden() reflects the explicit show/hide state immediately, which is
+    // the question being asked here.
+    const bool stripVisible = m_tabStrip && !m_tabStrip->isHidden();
     const int stripHeight = stripVisible ? m_tabStrip->sizeHint().height() : 0;
     if (m_tabStrip)
         m_tabStrip->setGeometry(0, barHeight, width(), stripHeight);
@@ -270,8 +279,20 @@ void BrowserWindow::rebuildTabStrip()
     // Torn down and rebuilt rather than patched: one button per tab is cheap,
     // and keeping a second model of which tabs exist is how the two drift.
     while (QLayoutItem *item = m_tabStripLayout->takeAt(0)) {
-        if (QWidget *w = item->widget())
+        if (QWidget *w = item->widget()) {
+            // Out of the widget tree now, not whenever the event loop gets to
+            // it. deleteLater alone leaves the old button a child of the strip:
+            // gone from the layout, so it keeps whatever geometry it last had,
+            // but still there to be hit-tested and still carrying its old
+            // handler. Rebuilding stacks them up — three closes all reading
+            // "Close t1" at one position — and a click meant for a tab lands on
+            // a leftover that closes the first one instead. deleteLater is
+            // still what frees it, because this can run from inside the very
+            // button's own clicked() handler.
+            w->hide();
+            w->setParent(nullptr);
             w->deleteLater();
+        }
         delete item;
     }
 
@@ -322,7 +343,26 @@ void BrowserWindow::rebuildTabStrip()
     // from it.
     const bool want = ids.size() > 1;
     m_tabStrip->setVisible(want && (!m_autoHide || m_toolbar->isVisible()));
+    // The buttons were added a moment ago and the layout has not recalculated,
+    // so sizeHint() still answers for the strip as it was — zero. layoutToolbar
+    // reads that sizeHint to decide the strip's height, which is how every tab
+    // button ended up 108x0: laid out, addressable, and impossible to click.
+    m_tabStripLayout->activate();
     layoutToolbar();
+
+    // And again once the event loop has turned. sizeHint() during a rebuild is
+    // not dependable: the buttons were created a moment ago and have not been
+    // polished, so the strip answers 0x0 as often as it answers its real
+    // height — measured going 21, then 0 again the next time a tab was added.
+    // Laying out twice costs nothing and is the difference between a strip you
+    // can click and one that is a zero-height line.
+    QTimer::singleShot(0, this, &BrowserWindow::layoutToolbar);
+
+    // The menu carries "Close tab", whose enabled state depends on how many
+    // tabs there are. This function is the one funnel every tab change already
+    // goes through, so the menu is refreshed here rather than from four call
+    // sites that would each have to remember.
+    rebuildMenu();
 }
 
 void BrowserWindow::setAutoHide(bool on)
@@ -408,6 +448,28 @@ void BrowserWindow::rebuildMenu()
     m_menu->addAction(QStringLiteral("Back"), m_view, &AnoaBrowser::back);
     m_menu->addAction(QStringLiteral("Forward"), m_view, &AnoaBrowser::forward);
     m_menu->addAction(QStringLiteral("Reload"), m_view, &AnoaBrowser::reload);
+    m_menu->addSeparator();
+    // The tab strip hides itself at one tab so a single-tab window stays plain,
+    // which left the "+" button reachable only once you already had two tabs —
+    // no way to open the second one from the window at all. These two are that
+    // way in, and the strip appears by itself the moment there is more than one.
+    QAction *newTab = m_menu->addAction(QStringLiteral("New tab"), this, [this]() {
+        const QString id = m_view->newTab();
+        if (!id.isEmpty())
+            m_view->selectTab(id);
+    });
+    newTab->setShortcut(QKeySequence::AddTab);
+
+    QAction *closeTab = m_menu->addAction(QStringLiteral("Close tab"), this, [this]() {
+        const QString id = m_view->activeTabId();
+        if (!id.isEmpty())
+            m_view->closeTab(id);
+    });
+    closeTab->setShortcut(QKeySequence::Close);
+    // The registry refuses the last tab, and a menu item that cannot work reads
+    // as a broken window rather than a deliberate rule.
+    closeTab->setEnabled(m_view->tabCount() > 1);
+
     m_menu->addSeparator();
     m_menu->addAction(QStringLiteral("Copy address"), this, [this]() {
         QGuiApplication::clipboard()->setText(m_view->url().toString());

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -526,6 +526,7 @@ void HttpServer::handleNewConnection()
             navUrl = QString::fromUtf8(bodyBytes.trimmed());
         }
 
+
         QUrl parsedUrl(navUrl);
         if (navUrl.isEmpty() || !parsedUrl.isValid() || parsedUrl.isRelative()) {
             sendResponse(socket, 400, "Bad Request", "invalid url", "text/plain");

--- a/tests/e2e/agent_cli.test.js
+++ b/tests/e2e/agent_cli.test.js
@@ -772,18 +772,32 @@ describe('Agent CLI (Suite 8)', () => {
 
   // AGENT-35: the quiet window is what makes it useful — a single request
   // finishing must not look like the end of a burst.
+  //
+  // A request has to happen first. Measured against a page that made none, both
+  // windows return at once and are indistinguishable: idle is "nothing
+  // outstanding and nothing finished recently", and on a silent page both halves
+  // are true from the start. An earlier version of this case did exactly that
+  // and passed on timing noise alone.
   it('wait --network-idle honours a longer quiet window', () => {
     anoa('open', 'example.com');
+
+    // Fetch anything; it is the completion that starts the clock. Cross-origin
+    // and rejected is fine — the helper counts a failed request as a finished
+    // one, which is the behaviour that matters here.
+    const kick = `fetch('http://127.0.0.1:${PORT}/json/version').catch(function(){})`;
+
+    anoa('eval', kick);
     const short = Date.now();
     anoa('wait', '--network-idle', '--network-idle-ms', '200', '--timeout', '8000');
     const shortMs = Date.now() - short;
 
+    anoa('eval', kick);
     const long = Date.now();
-    anoa('wait', '--network-idle', '--network-idle-ms', '1200', '--timeout', '8000');
+    anoa('wait', '--network-idle', '--network-idle-ms', '1500', '--timeout', '8000');
     const longMs = Date.now() - long;
 
-    assert.ok(longMs > shortMs,
-              `1200ms window (${longMs}ms) was not longer than 200ms (${shortMs}ms)`);
+    assert.ok(longMs > shortMs + 500,
+              `1500ms window (${longMs}ms) was not meaningfully longer than 200ms (${shortMs}ms)`);
   });
 
   // AGENT-36: wait --download with nothing downloading returns rather than


### PR DESCRIPTION
Reported as *"I click the tab and it disappears"*, which turned out to be three separate faults in the same strip — plus one in the live view's address bar.

## It had no height

`layoutToolbar()` decided the strip's height from `isVisible()`, which is false until the show event has been delivered — and `rebuildTabStrip()` calls `setVisible()` then `layoutToolbar()` in the same turn, so the strip was always measured before it counted as visible. It also read `sizeHint()` straight after rebuilding, when the new buttons are unpolished and the layout answers `0x0` as often as `21`.

The accessibility tree showed it exactly:

```
AXButton | t1  https://example.com/  | 1170,408 108x0
AXButton | t2  https://www.iana.org/ | 1317,408 170x0
```

Present, addressable, impossible to click. Three changes because it was three failures — `isHidden()` instead of `isVisible()`, an explicit `activate()` before measuring, and a second `layoutToolbar()` on the next event loop turn, which is what makes it hold. Now **108x21 across four consecutive rebuilds**.

## Old buttons stayed in the widget tree

The rebuild took each button out of the layout and called `deleteLater`, which leaves it a *child of the strip* until the event loop gets to it — out of the layout, so keeping whatever geometry it last had, but still hit-testable and still carrying its old handler. They stack up: three close buttons all reading `Close t1` at one position. A click meant for a tab could land on a leftover that closed the first one.

They are hidden and unparented at once now, and still freed by `deleteLater`, because the rebuild can run from inside a button's own `clicked` handler.

## There was no way to open a second tab

The strip hides itself at one tab so a single-tab window stays plain — which left the **"+" reachable only once you already had two tabs.** A dead end. **New tab** and **Close tab** are on the menu now with the platform shortcuts (⌘T / ⌘W), and the strip appears by itself as soon as there is more than one. Close tab is disabled at one tab, because the registry refuses it and a control that cannot work reads as a broken window.

## And the live view's address bar did nothing

Typing an address without a scheme was silently dropped. `/render/navigate` is strict on purpose — a client posting `relative/path` should get a 400, and RND-13 says so — but the viewer sent the raw text through and then swallowed the 400 in a bare `catch`.

The rule now lives at the address bar, which is where the terminal viewer and the desktop window each apply it (see `url_input.h`, which says the rule belongs at every surface that takes an address from a human — the live view was the third one and had been missed). The viewer reports failures over the view instead of eating them.

Verified: `example.org`, `www.iana.org`, `debian.org` and `localhost:9222` all resolve the way the other two surfaces resolve them, and `relative/path` still 400s at the API.

## Verified against the real window

Through the accessibility API, on the actual GUI: ⌘T opens a tab, clicking a tab selects it, and clicking the **fourth** tab's close button closes the fourth tab. The uniform `Close t1` labels that remain are a Qt accessibility *reporting* quirk, not the widgets — the click lands on the right one.

| suite | result |
|---|---|
| integration | 118 passed, 21 skipped |
| e2e agent CLI | 44 passed |
| unit · port layout · smoke | 4 · 13 · 5 |