### PR TITLE
fix: anoa close now actually closes the browser (#30)

### DIFF
--- a/pages/docs.html
+++ b/pages/docs.html
@@ -540,7 +540,7 @@ environment.systemPackages = [ inputs.anoa.packages.${system}.anoa ];</pre>
 <pre class="term"><span class="p">$</span> anoa skills list                  <span class="o">what skill documents this binary carries</span>
 <span class="p">$</span> anoa skills get core              <span class="o">the core workflow, for an agent to read</span>
 <span class="p">$</span> anoa skills get commands          <span class="o">every command, with its arguments</span>
-<span class="p">$</span> anoa close                        <span class="o">ask the browser to exit</span></pre>
+<span class="p">$</span> anoa close                        <span class="o">stop the browser; returns once it is gone</span></pre>
         <p style="margin-top:16px">The skill documents are printed straight to stdout, meant
         to be pasted into a context window rather than read on a screen.</p>
       </section>

--- a/src/agent/agent_cli.cpp
+++ b/src/agent/agent_cli.cpp
@@ -8,6 +8,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QTcpSocket>
 #include <QTextStream>
 #include <QTimer>
 #include <QUrl>
@@ -1641,7 +1642,25 @@ int dispatchVerb(Session &session, const QString &verb, QStringList args, bool j
         if (!r.ok)
             return fail(QStringLiteral("this browser cannot be closed over CDP — "
                                        "stop the process that started it"));
-        return Ok;
+        // The reply means the request was accepted, not that the browser is
+        // gone. Wait for the port to stop accepting connections, so exit 0 is
+        // a promise a script can act on — start another browser on this port,
+        // or check that nothing is left running.
+        QElapsedTimer since;
+        since.start();
+        while (since.elapsed() < 10000) {
+            QTcpSocket probe;
+            probe.connectToHost(host, static_cast<quint16>(port));
+            if (!probe.waitForConnected(500))
+                return Ok;
+            probe.abort();
+            QEventLoop tick;
+            QTimer::singleShot(100, &tick, &QEventLoop::quit);
+            tick.exec();
+        }
+        return fail(QStringLiteral("the browser accepted close but is still listening on %1:%2")
+                        .arg(host)
+                        .arg(port));
     }
 
     return fail(QStringLiteral("unknown command: %1").arg(verb), Usage);

--- a/src/agent/agent_help.cpp
+++ b/src/agent/agent_help.cpp
@@ -161,7 +161,7 @@ const Group kGroups[] = {
   anoa skills get commands          every command, with its arguments
   anoa exec [file]                  run many commands on one connection; `-`
                                     or no argument reads them from stdin
-  anoa close                        ask the browser to exit
+  anoa close                        stop the browser; returns once it is gone
 
   Add --json to any command for machine-readable output.
   Exit codes: 0 ok · 1 command failed · 2 usage · 3 no browser listening)"},

--- a/src/agent/agent_skill.cpp
+++ b/src/agent/agent_skill.cpp
@@ -412,7 +412,7 @@ subscribed to the events in time. Consequences worth knowing:
 | `anoa skills list` | what this binary carries |
 | `anoa skills get core` | the workflow: how to drive a page |
 | `anoa skills get commands` | this document |
-| `anoa close` | ask the browser to exit |
+| `anoa close` | stop the browser; exit 0 means the process is gone and the port is free |
 
 ## Not implemented
 

--- a/src/cdp/cdp_extensions.cpp
+++ b/src/cdp/cdp_extensions.cpp
@@ -2,9 +2,11 @@
 #include "cdp/tab_host.h"
 #include "pdf/pdf_handler.h"
 
+#include <QCoreApplication>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QTimer>
 
 static QString stubResult(const QJsonObject &cmd)
 {
@@ -114,6 +116,19 @@ QString CdpExtensions::handleBrowser(const QJsonObject &cmd)
     // "Browser context management is not supported". Pass everything else
     // (e.g. Browser.getVersion) through to Chromium.
     const QString method = cmd.value(QStringLiteral("method")).toString();
+    if (method == QLatin1String("Browser.close")) {
+        // Chromium answers Browser.close with an empty success and then keeps
+        // running: the browser it would close is one Qt owns and it has no
+        // handle on it. So `anoa close` exited 0 while the process and its
+        // renderers stayed alive — the failure mode this codebase specialises
+        // in, an endpoint reporting success without acting.
+        //
+        // Quit on a later turn of the event loop, not now: this reply still has
+        // to reach the socket. Unwinding main() from there is what destroys the
+        // profile, which is what flushes cookies — the same path SIGTERM takes.
+        QTimer::singleShot(150, qApp, &QCoreApplication::quit);
+        return stubResult(cmd);
+    }
     if (method == QLatin1String("Browser.setDownloadBehavior")
             || method == QLatin1String("Browser.getWindowForTarget")
             || method == QLatin1String("Browser.setWindowBounds")

--- a/tests/e2e/agent_cli.test.js
+++ b/tests/e2e/agent_cli.test.js
@@ -811,3 +811,48 @@ describe('Agent CLI (Suite 8)', () => {
   });
 
 });
+
+// Issue #30. Its own describe with its own port and its own browser, because
+// the subject of the test is killing the browser and Suite 8 shares one.
+describe('Agent CLI — close (issue #30)', () => {
+  const CLOSE_PORT = PORT + 10;
+  let victim;
+
+  const closeAnoa = (...args) => run([...args, '--port', String(CLOSE_PORT)]);
+
+  before(async () => {
+    assert.ok(BIN, 'no built binary');
+    victim = spawn(BIN, ['--headless', '--no-sandbox', '--port', String(CLOSE_PORT)],
+                   { stdio: 'ignore' });
+    const deadline = Date.now() + 30000;
+    for (;;) {
+      if (closeAnoa('status').code === 0) break;
+      assert.ok(Date.now() < deadline, `browser never came up on ${CLOSE_PORT}`);
+      await new Promise(r => setTimeout(r, 500));
+    }
+  });
+
+  after(() => {
+    if (victim) victim.kill('SIGKILL');
+  });
+
+  // AGENT-37: close has to mean closed. It reported exit 0 while the process,
+  // its renderers and the port all stayed up, so anything trusting the exit
+  // code left a whole browser engine running.
+  it('close stops the browser, and exit 0 means it is gone', async () => {
+    const r = closeAnoa('close');
+    assert.equal(r.code, 0, r.err);
+
+    // The exit code alone is the claim under test: by the time close returns,
+    // nothing may be listening.
+    assert.equal(closeAnoa('status').code, 3, 'port still answering after close');
+
+    // And the process itself is gone, not just its socket.
+    const exited = await Promise.race([
+      new Promise(res => victim.once('exit', () => res(true))),
+      new Promise(res => setTimeout(() => res(false), 10000)),
+    ]);
+    assert.ok(exited, 'the browser process outlived close');
+    victim = null;
+  });
+});


### PR DESCRIPTION
Fixes #30.

### What was wrong

`anoa close` exited `0` while the browser kept running — process, renderers and port all still up, and `anoa status` still answering `0`. Calling it twice changed nothing.

`close` sends `Browser.close`, which was passed through to Chromium. Chromium answers it with an empty success and then does nothing: the browser it would close is one Qt owns, and it has no handle on it. The CLI saw a successful reply and reported success. Same shape as the other bugs in this codebase — an endpoint reporting success without acting.

### The fix

- `CdpExtensions::handleBrowser` handles `Browser.close` itself: reply, then quit on a later turn of the event loop so the reply reaches the socket first. Quitting unwinds `main()`, which destroys the profile, which flushes cookies — the same path `SIGTERM` already took. Verified: a named profile writes its `Cookies` file on `close`.
- `close` no longer trusts the reply. It waits for the port to stop accepting connections and exits `1` with a message if it does not, so `exit 0` is something a script can act on — start another browser on that port, or check nothing is left running. This is what the issue asked for.

### Testing

`AGENT-37` in `tests/e2e/agent_cli.test.js`, on its own port with its own browser (the suite shares one, and this test kills it). It asserts the three things the issue reports: `close` exits 0, `status` immediately after exits 3, and the process itself exits.

Confirmed failing against the old binary first (`0 !== 3`, "port still answering after close"), passing after.

Also run: full e2e agent suite (45 pass), integration suites (118 pass, 21 skipped — the known macOS `script` skips), unit tests (4/4), and the Playwright suite. That last one matters for CI: Playwright and Puppeteer share one browser on 9222 and Playwright's `afterAll` calls `browser.close()` — over `connectOverCDP` that only disconnects, so the shared browser survives and the Puppeteer step still has one to talk to. Checked, not assumed.

The reproduction from the issue, on the fixed build:

```
close exit: 0
main gone
renderer gone
status after close: 3 (expect 3)
```

### Docs

`anoa help agents`, `anoa skills get commands` and the web docs said "ask the browser to exit". Now: "stop the browser; returns once it is gone".