### PR TITLE
chore(release): 0.15.0 -> 0.15.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(anoa VERSION 0.15.0 LANGUAGES CXX)
+project(anoa VERSION 0.15.1 LANGUAGES CXX)
 
 # CI injects the git tag here so the tag is the single source of truth for the
 # version — CMakeLists.txt never needs a manual bump for releases. The value

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
       # Keep this in step with CMakeLists.txt. It is passed to the build rather
       # than read from it, so `nix run` reports the same string a release does.
-      version = "0.15.0";
+      version = "0.15.1";
     in
     {
       packages = forEach (pkgs: rec {

--- a/pages/index.html
+++ b/pages/index.html
@@ -39,7 +39,7 @@
         or any CDP client. One binary, no driver to install, no headless-versus-real
         distinction to reason about.</p>
         <div class="badges">
-          <span>latest <b>v0.15.0</b></span>
+          <span>latest <b>v0.15.1</b></span>
           <span>macOS · Linux · Windows</span>
           <span>x86_64 · <b>aarch64</b></span>
           <span>Qt 6 + Chromium</span>

--- a/pages/llms.txt
+++ b/pages/llms.txt
@@ -17,7 +17,7 @@ Also packaged as a Nix flake for x86_64-linux, aarch64-linux and aarch64-darwin
 has no qtwebengine for x86_64-darwin, so Intel Macs use Homebrew. Flakes are
 still experimental, so a fresh Nix needs `experimental-features = nix-command
 flakes` in ~/.config/nix/nix.conf before any of those commands work.
-`anoa terminal` is POSIX-only. Latest release: v0.15.0.
+`anoa terminal` is POSIX-only. Latest release: v0.15.1.
 
 ## Start here
 


### PR DESCRIPTION
Version bump for the 0.15.1 fix release: `anoa close` now actually closes the browser (#30, fixed in #31).

CMakeLists.txt, flake.nix, and the two places the website names the current version.